### PR TITLE
Automated Changelog Entry for 0.1.4 on main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,9 +4,23 @@ All notable changes to this project will be documented in this file.
 
 <!-- <START NEW CHANGELOG ENTRY> -->
 
-## 0.1.3
+## 0.1.4
+
+([Full Changelog](https://github.com/jupyter-server/jupyter_server_ydoc/compare/v0.1.3...3b6db1b0cb6e4a060af9f350b1d62396992931f9))
+
+### Merged PRs
+
+- Fix changelog [#8](https://github.com/jupyter-server/jupyter_server_ydoc/pull/8) ([@davidbrochart](https://github.com/davidbrochart))
+
+### Contributors to this release
+
+([GitHub contributors page for this release](https://github.com/jupyter-server/jupyter_server_ydoc/graphs/contributors?from=2022-07-11&to=2022-07-11&type=c))
+
+[@davidbrochart](https://github.com/search?q=repo%3Ajupyter-server%2Fjupyter_server_ydoc+involves%3Adavidbrochart+updated%3A2022-07-11..2022-07-11&type=Issues)
 
 <!-- <END NEW CHANGELOG ENTRY> -->
+
+## 0.1.3
 
 ## 0.1.2
 


### PR DESCRIPTION
Automated Changelog Entry for 0.1.4 on main

After merging this PR run the "Full Release" Workflow on your fork of `jupyter_releaser` with the following inputs
| Input  | Value |
| ------------- | ------------- |
| Target | jupyter-server/jupyter_server_ydoc  |
| Branch  | main  |
| Version Spec | next |
| Since | v0.1.3 |