### PR TITLE
Use fileId instead of path in the store

### DIFF
--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -84,8 +84,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
                     )
 
                 file = self._file_loaders[file_id]
-                path = Path(self._file_id_manager.get_path(file_id))
-                updates_file_path = str(path.parent / f".{file_type}:{file_id}.y")
+                updates_file_path = f".{file_type}:{file_id}.y"
                 ystore = self._ystore_class(path=updates_file_path, log=self.log)
                 self.room = DocumentRoom(
                     self._room_id,

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -6,7 +6,6 @@ from __future__ import annotations
 import asyncio
 import json
 import uuid
-from pathlib import Path
 from typing import Any
 
 from jupyter_server.auth import authorized

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -84,9 +84,8 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
                     )
 
                 file = self._file_loaders[file_id]
-                path = self._file_id_manager.get_path(file_id)
-                path = Path(path)
-                updates_file_path = str(path.parent / f".{file_type}:{path.name}.y")
+                path = Path(self._file_id_manager.get_path(file_id))
+                updates_file_path = str(path.parent / f".{file_type}:{file_id}.y")
                 ystore = self._ystore_class(path=updates_file_path, log=self.log)
                 self.room = DocumentRoom(
                     self._room_id,


### PR DESCRIPTION
fixes #165 

Use fileId instead of path in the store.

If we use the path instead of the file ID, when renaming the file and creating a new file with the old name, the new file will have the updates of the old one (Kind of. If the content on disk differs from the store, the disk has priority).