### PR TITLE
Clean up

### DIFF
--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -216,7 +216,6 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         On message receive.
         """
         message_type = message[0]
-        print("message type:", message_type)
 
         if message_type == YMessageType.AWARENESS:
             # awareness

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,8 +31,7 @@ dependencies = [
     "jupyter_ydoc>=1.0.1,<2.0.0",
     "ypy-websocket>=0.12.1,<0.13.0",
     "jupyter_events",
-    "jupyter_server_fileid>=0.6.0,<1",
-    "jsonschema[format-nongpl,format_nongpl]<4.18.0" # https://github.com/jupyter/jupyter_events/pull/80
+    "jupyter_server_fileid>=0.6.0,<1"
 ]
 dynamic = ["version", "description", "authors", "urls", "keywords"]
 


### PR DESCRIPTION
Removes print and the `jsonschema` dependency. The dependency was pinned to avoid the CI failures because of a deprecation warning.