### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ pip install jupyter-collaboration
 Or using ``conda``/``mamba``:
 
 ```bash
-conda install jupyter-collaboration
+conda install -c conda-forge jupyter-collaboration
 ```
 
 ### Testing


### PR DESCRIPTION
Changed the conda install method to reflect the fact that the collab module is now available on the conda-forge channel. Without this change, it will not be possible to use conda to install the module