### PR TITLE
Fix CI (Backport #221 into 1.x)

### DIFF
--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -20,6 +20,9 @@ jobs:
       - name: Configure git to use https
         run: git config --global hub.protocol https
 
+      - name: Install hub
+        run: sudo apt-get update && sudo apt-get install -y hub
+
       - name: Checkout the branch from the PR that triggered the job
         run: hub pr checkout ${{ github.event.pull_request.number }}
         env:

--- a/.github/workflows/license-header.yml
+++ b/.github/workflows/license-header.yml
@@ -20,11 +20,8 @@ jobs:
       - name: Configure git to use https
         run: git config --global hub.protocol https
 
-      - name: Install hub
-        run: sudo apt-get update && sudo apt-get install -y hub
-
       - name: Checkout the branch from the PR that triggered the job
-        run: hub pr checkout ${{ github.event.pull_request.number }}
+        run: gh pr checkout ${{ github.event.pull_request.number }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,7 +145,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install the Python dependencies
         run: |
-          pip install --pre -e ".[test]"
+          pip install -e ".[test]"
       - name: List installed packages
         run: |
           pip freeze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -71,10 +71,17 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, windows-latest, macos-latest]
-        python-version: ["3.8", "3.11"]
-        include:
-          - os: ubuntu-latest
-            python-version: "pypy-3.8"
+
+        python-version: ["3.8", "3.11", "3.12"]
+        # PyPy is not supported because we use the file_id_manager. See:
+        # https://github.com/jupyter-server/jupyter_server_fileid/issues/44
+        #include:
+        #  - os: ubuntu-latest
+        #    python-version: "pypy-3.8"
+        exclude:
+          - os: windows-latest
+            python-version: "3.12"
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -138,7 +145,12 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install the Python dependencies
         run: |
+<<<<<<< HEAD
           pip install --pre -e ".[test]"
+=======
+          pip install -e ".[test]"
+
+>>>>>>> 7ae9c62 (Fix CI (#221))
       - name: List installed packages
         run: |
           pip freeze

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -145,12 +145,7 @@ jobs:
         uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - name: Install the Python dependencies
         run: |
-<<<<<<< HEAD
           pip install --pre -e ".[test]"
-=======
-          pip install -e ".[test]"
-
->>>>>>> 7ae9c62 (Fix CI (#221))
       - name: List installed packages
         run: |
           pip freeze

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -107,7 +107,9 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
             await self._websocket_server.start_room(self.room)
             self._websocket_server.add_room(self._room_id, self.room)
 
-        return await super().prepare()
+        res = super().prepare()
+        if res is not None:
+            return await res
 
     def initialize(
         self,

--- a/package.json
+++ b/package.json
@@ -8,13 +8,13 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/jupyterlab/jupyter_collaboration",
+  "homepage": "https://github.com/jupyterlab/jupyter-collaboration",
   "bugs": {
-    "url": "https://github.com/jupyterlab/jupyter_collaboration/issues"
+    "url": "https://github.com/jupyterlab/jupyter-collaboration/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyter_collaboration.git"
+    "url": "https://github.com/jupyterlab/jupyter-collaboration.git"
   },
   "license": "BSD-3-Clause",
   "author": {
@@ -67,6 +67,5 @@
     "stylelint-prettier": "^3.0.0",
     "typedoc": "~0.23.28",
     "typescript": "~5.0.4"
-  },
-  "packageManager": "yarn@3.5.0"
+  }
 }

--- a/packages/collaboration-extension/package.json
+++ b/packages/collaboration-extension/package.json
@@ -7,13 +7,13 @@
     "jupyterlab",
     "jupyterlab-extension"
   ],
-  "homepage": "https://github.com/jupyterlab/jupyter_collaboration",
+  "homepage": "https://github.com/jupyterlab/jupyter-collaboration",
   "bugs": {
-    "url": "https://github.com/jupyterlab/jupyter_collaboration/issues"
+    "url": "https://github.com/jupyterlab/jupyter-collaboration/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyter_collaboration.git"
+    "url": "https://github.com/jupyterlab/jupyter-collaboration.git"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -2,13 +2,13 @@
   "name": "@jupyter/collaboration",
   "version": "1.2.0",
   "description": "JupyterLab - Real-Time Collaboration Widgets",
-  "homepage": "https://github.com/jupyterlab/jupyter_collaboration",
+  "homepage": "https://github.com/jupyterlab/jupyter-collaboration",
   "bugs": {
-    "url": "https://github.com/jupyterlab/jupyter_collaboration/issues"
+    "url": "https://github.com/jupyterlab/jupyter-collaboration/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyter_collaboration.git"
+    "url": "https://github.com/jupyterlab/jupyter-collaboration.git"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -2,13 +2,13 @@
   "name": "@jupyter/docprovider",
   "version": "1.2.0",
   "description": "JupyterLab - Document Provider",
-  "homepage": "https://github.com/jupyterlab/jupyter_collaboration",
+  "homepage": "https://github.com/jupyterlab/jupyter-collaboration",
   "bugs": {
-    "url": "https://github.com/jupyterlab/jupyter_collaboration/issues"
+    "url": "https://github.com/jupyterlab/jupyter-collaboration/issues"
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/jupyterlab/jupyter_collaboration.git"
+    "url": "https://github.com/jupyterlab/jupyter-collaboration.git"
   },
   "license": "BSD-3-Clause",
   "author": "Project Jupyter",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -47,7 +47,7 @@ test = [
     "jupyter_server[test]>=2.0.0",
     "pytest>=7.0",
     "pytest-cov",
-    "pytest-asyncio"
+    "websockets"
 ]
 docs = [
     "jupyterlab>=4.0.0",
@@ -139,6 +139,8 @@ filterwarnings = [
     "module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
     # In PyPy/Cython: see https://github.com/yaml/pyyaml/issues/688
     "ignore:can't resolve package from __spec__ or __package__, falling back on __name__ and __path__:ImportWarning",
+    # see https://github.com/dateutil/dateutil/issues/1314
+    "ignore:.*datetime.utcfromtimestamp\\(\\) is deprecated.*:DeprecationWarning:",
 ]
 
 [tool.mypy]

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -7,6 +7,8 @@ import asyncio
 from datetime import datetime
 from typing import Any
 
+from jupyter_server import _tz as tz
+
 from jupyter_collaboration.loaders import FileLoader, FileLoaderMapping
 
 

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -7,9 +7,6 @@ import asyncio
 from datetime import datetime
 from typing import Any
 
-import pytest
-from jupyter_server import _tz as tz
-
 from jupyter_collaboration.loaders import FileLoader, FileLoaderMapping
 
 
@@ -45,7 +42,6 @@ class FakeContentsManager:
         return self.model
 
 
-@pytest.mark.asyncio
 async def test_FileLoader_with_watcher():
     id = "file-4567"
     path = "myfile.txt"
@@ -78,7 +74,6 @@ async def test_FileLoader_with_watcher():
         await loader.clean()
 
 
-@pytest.mark.asyncio
 async def test_FileLoader_without_watcher():
     id = "file-4567"
     path = "myfile.txt"
@@ -110,7 +105,6 @@ async def test_FileLoader_without_watcher():
         await loader.clean()
 
 
-@pytest.mark.asyncio
 async def test_FileLoaderMapping_with_watcher():
     id = "file-4567"
     path = "myfile.txt"


### PR DESCRIPTION
* Remove packageManager entry

* Fix for Python 3.12

* Remove use of pytest-asyncio

* Fix mypy

* Re-enable Python 3.11

* Don't test win/py3.12

* Fix URLs in package.json

* Update yarn.lock

* Revert previous commit

* Remove pip --pre