### PR TITLE
Fix cancellation of file save operation

### DIFF
--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -235,6 +235,9 @@ class DocumentRoom(YRoom):
             # the document is being saved, cancel that
             saving_document.cancel()
 
+        # all async code (i.e. await statements) must be part of this try/except block
+        # because this coroutine is run in a cancellable task and cancellation is handled here
+
         try:
             # save after X seconds of inactivity
             await asyncio.sleep(self._save_delay)

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -234,12 +234,11 @@ class DocumentRoom(YRoom):
         if saving_document is not None and not saving_document.done():
             # the document is being saved, cancel that
             saving_document.cancel()
-            await saving_document
-
-        # save after X seconds of inactivity
-        await asyncio.sleep(self._save_delay)
 
         try:
+            # save after X seconds of inactivity
+            await asyncio.sleep(self._save_delay)
+
             self.log.info("Saving the content from room %s", self._room_id)
             await self._file.maybe_save_content(
                 {
@@ -252,6 +251,9 @@ class DocumentRoom(YRoom):
                 self._document.dirty = False
 
             self._emit(LogLevel.INFO, "save", "Content saved.")
+
+        except asyncio.CancelledError:
+            return
 
         except OutOfBandChanges:
             self.log.info("Out-of-band changes. Overwriting the content in room %s", self._room_id)


### PR DESCRIPTION
When we schedule a file saving and one has already been scheduled but not yet completed (for instance, by typing a character and then another one less than one second later), we need to cancel the previously scheduled one. The proper way to do it is not by calling `.cancel()` on the task and awaiting it, but by handling the `CancelledError` exception inside the task. In our case, we want to do nothing if the task is cancelled, so we just return.