### PR TITLE
Refactor `DocumentRoom`, throttle saves instead of debouncing saves

### DIFF
--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -120,7 +120,16 @@ class DocumentRoom(YRoom):
                         # YDoc not found in the YStore, create the document from the source file (no change history)
                         pass
 
-                if not read_from_source:
+                if read_from_source:
+                    self._emit(LogLevel.INFO, "load", "Content loaded from disk.")
+                    self.log.info(
+                        "Content in room %s loaded from file %s", self._room_id, self._file.path
+                    )
+                    self._document.source = model["content"]
+
+                    if self.ystore:
+                        await self.ystore.encode_state_as_update(self.ydoc)
+                else:
                     # if YStore updates and source file are out-of-sync, resync updates with source
                     if self._document.source != model["content"]:
                         # TODO: Delete document from the store.
@@ -134,15 +143,6 @@ class DocumentRoom(YRoom):
                         )
                         read_from_source = True
 
-                if read_from_source:
-                    self._emit(LogLevel.INFO, "load", "Content loaded from disk.")
-                    self.log.info(
-                        "Content in room %s loaded from file %s", self._room_id, self._file.path
-                    )
-                    self._document.source = model["content"]
-
-                    if self.ystore:
-                        await self.ystore.encode_state_as_update(self.ydoc)
 
                 self._document.dirty = False
                 self.ready = True

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -131,6 +131,19 @@ class DocumentRoom(YRoom):
                 # YDoc not found in the YStore, create the document from the source file (no change history)
                 pass
 
+        if not read_from_source and self._document.source != model["content"]:
+            # TODO: Delete document from the store.
+            self._emit(
+                LogLevel.INFO, "initialize", "The file is out-of-sync with the ystore."
+            )
+            self.log.info(
+                "Content in file %s is out-of-sync with the ystore %s",
+                self._file.path,
+                self.ystore.__class__.__name__,
+            )
+            read_from_source = True
+
+        # if YStore updates and source file are out-of-sync, resync updates with source
         if read_from_source:
             self._emit(LogLevel.INFO, "load", "Content loaded from disk.")
             self.log.info(
@@ -140,20 +153,6 @@ class DocumentRoom(YRoom):
 
             if self.ystore:
                 await self.ystore.encode_state_as_update(self.ydoc)
-        else:
-            # if YStore updates and source file are out-of-sync, resync updates with source
-            if self._document.source != model["content"]:
-                # TODO: Delete document from the store.
-                self._emit(
-                    LogLevel.INFO, "initialize", "The file is out-of-sync with the ystore."
-                )
-                self.log.info(
-                    "Content in file %s is out-of-sync with the ystore %s",
-                    self._file.path,
-                    self.ystore.__class__.__name__,
-                )
-                read_from_source = True
-
 
         self.ready = True
         self._emit(LogLevel.INFO, "initialize", "Room initialized")

--- a/jupyter_collaboration/rooms.py
+++ b/jupyter_collaboration/rooms.py
@@ -155,7 +155,6 @@ class DocumentRoom(YRoom):
                 read_from_source = True
 
 
-        self._document.dirty = False
         self.ready = True
         self._emit(LogLevel.INFO, "initialize", "Room initialized")
 
@@ -205,7 +204,6 @@ class DocumentRoom(YRoom):
             return
 
         self._document.source = model["content"]
-        self._document.dirty = False
 
     def _on_document_change(self, target: str, event: Any) -> None:
         """
@@ -290,7 +288,6 @@ class DocumentRoom(YRoom):
                 return None
 
             self._document.source = model["content"]
-            self._document.dirty = False
             self._emit(LogLevel.INFO, "overwrite", "Out-of-band changes while saving.")
 
         except Exception as e:


### PR DESCRIPTION
## Description

- Refactors the `DocumentRoom` class to not rely on the `asyncio.Lock` context manager. This greatly improves readability by reducing nesting and reliance on the `asyncio` API.

- Throttles saves instead of debouncing them, ensuring that document changes will be flushed to disk on a minimum interval. Related: #244

- All existing unit tests pass locally.

## Change summary

- Removes `self._initialization_lock`.
    - This is not necessary as long as the `initialize()` method is only called once and awaited, as is the case in this extension. This is a very reasonable usage constraint. Furthermore, in `asyncio`, [locks do not provide thread safety](https://docs.python.org/3/library/asyncio-sync.html#asyncio.Lock), contrary to the original docstring of this method.

- Removes `self._update_lock`.
  - The purpose of this lock is to prevent `self._on_document_change()` from being called while the lock is held. Removing the locks results in a save loop, as without the lock, `self._maybe_save_document()` would trigger `self._on_document_change()`.
  - However, the save loop was caused by a single `self._document.dirty = False` statement, which could have been removed without consequence. See below.

- Throttles saves instead of debouncing saves by cancelling the previous task
  - Throttling seems preferable to debouncing here, as debouncing could result in the document not being saved if the document is being changed too frequently, which may arise in rooms with lots of collaborators.
  - Previously, every time a new `self._maybe_save_document()` task was started, the previous task was cancelled if it was in progress. The method required the previous task as an argument, which resulted in a weird way of calling the method:

    ```python
    self._saving_document = asyncio.create_task(
        self._maybe_save_document(self._saving_document)
    )
    ```

  - The new implementation of `self._maybe_save_document()` does not require an extra argument or `task.cancel()`; instead it relies on knowledge of its own state, stored in a couple of new instance attributes. Here is an overview of the algorithm:
    - If a previous `self._maybe_save_document()` task is waiting on `self._save_delay`, then the current task can return early, as that previous task will save the Ydoc anyways. 
    - If a previous `self._maybe_save_document()` task is currently saving via `FileLoader`, then the current task should set `self._should_resave = True` and then return. Later, when the previous task is done saving, if this attribute is `True`, then it will re-run itself via `asyncio.create_task(self.maybe_save_document())`.

- Removed `self._document.dirty = False` statements
  - This `dirty` attribute was only referenced in a single unit test, and I could not find it mentioned in `pycrdt` or `pycrdt-websocket`. I removed this because setting `self._document.dirty` triggers the `_on_document_change()` observer, causing a save loop in this branch. Removing the statement from `self._maybe_save_document()` allows for `self._update_lock` to be removed.
  - It seems preferable to avoid triggering a document change when handling one, rather than relying on a lock.
