### PR TITLE
Make user's cursor "tooltip-on-hover" faster and wider

### DIFF
--- a/packages/collaboration/src/cursors.ts
+++ b/packages/collaboration/src/cursors.ts
@@ -251,7 +251,7 @@ const userHover = hoverTooltip(
           continue;
         }
         // Use some margin around the cursor to display the user.
-        if (head.index - 1 <= pos && pos <= head.index + 1) {
+        if (head.index - 3 <= pos && pos <= head.index + 3) {
           return {
             pos: head.index,
             above: true,
@@ -271,7 +271,8 @@ const userHover = hoverTooltip(
     return null;
   },
   {
-    hideOn: (tr, tooltip) => !!tr.annotation(remoteSelectionsAnnotation)
+    hideOn: (tr, tooltip) => !!tr.annotation(remoteSelectionsAnnotation),
+    hoverTime: 0
   }
 );
 


### PR DESCRIPTION
When you hover over a user's cursor, it shows their name. 

This PR addresses two UX issues around the current behavior:
1. The width around the cursor where this hover action happens is quite small. 
2. The delay for when the name appears is quite long. 

While these are fairly subjective settings, I believe this PR is a better default/minimum for this behavior. 