### PR TITLE
Use WebSocket _room_id attribute directly

### DIFF
--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -215,7 +215,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
 
             self._emit(LogLevel.INFO, "initialize", "New client connected.")
         else:
-            if self.room.room_id != "JupyterLab:globalAwareness":
+            if self._room_id != "JupyterLab:globalAwareness":
                 self._emit_awareness_event(self.current_user.username, "join")
 
     async def send(self, message):
@@ -296,7 +296,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
             # keep the document for a while in case someone reconnects
             self.log.info("Cleaning room: %s", self._room_id)
             self.room.cleaner = asyncio.create_task(self._clean_room())
-        if self.room.room_id != "JupyterLab:globalAwareness":
+        if self._room_id != "JupyterLab:globalAwareness":
             self._emit_awareness_event(self.current_user.username, "leave")
 
     def _emit(self, level: LogLevel, action: str | None = None, msg: str | None = None) -> None:
@@ -339,7 +339,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
 
         async with self._room_lock(self._room_id):
             # Remove the room from the websocket server
-            self.log.info("Deleting Y document from memory: %s", self.room.room_id)
+            self.log.info("Deleting Y document from memory: %s", self._room_id)
             self._websocket_server.delete_room(room=self.room)
 
             # Clean room


### PR DESCRIPTION
When connecting to an already opened room, the WebSocket's `room` is a [YRoom](https://github.com/jupyterlab/jupyter-collaboration/blob/8f55ea5e62f22a49619d19e846d1b16f06bc47e1/jupyter_collaboration/handlers.py#L81) which doesn't have a `room_id`.
Anyway, the room ID is the WebSocket's path, so it is equivalent to use it directly rather than from other objects where it is copied.