### PR TITLE
Add a public API for getting a read-only view of the shared model

### DIFF
--- a/docs/source/developer/python_api.rst
+++ b/docs/source/developer/python_api.rst
@@ -4,6 +4,25 @@
 Python API
 ==========
 
+``jupyter_collaboration`` instantiates :any:`YDocExtension` and stores it under ``serverapp.settings`` dictionary, under the ``"jupyter_collaboration"`` key.
+This instance can be used in other extensions to access the public API methods.
+
+For example, to access a read-only view of the shared notebook model in your jupyter-server extension, you can use the :any:`get_document` method:
+
+.. code-block::
+
+   collaboration = serverapp.settings["jupyter_collaboration"]
+   document = collaboration.get_document(
+       path='Untitled.ipynb',
+       content_type="notebook",
+       file_format="json"
+   )
+   content = document.get()
+
+
+API Reference
+-------------
+
 .. automodule:: jupyter_collaboration.app
   :members:
   :inherited-members:

--- a/jupyter_collaboration/app.py
+++ b/jupyter_collaboration/app.py
@@ -158,12 +158,7 @@ class YDocExtension(ExtensionApp):
             return None
 
         if isinstance(room, DocumentRoom):
-            update = room.ydoc.get_update()
-
-            fork_ydoc = Doc()
-            fork_ydoc.apply_update(update)
-
-            return YDOCS.get(content_type, YDOCS["file"])(fork_ydoc)
+            return room._document
 
         return None
 

--- a/jupyter_collaboration/app.py
+++ b/jupyter_collaboration/app.py
@@ -142,10 +142,10 @@ class YDocExtension(ExtensionApp):
         file_format: Literal["json", "text"],
         copy: bool = True,
     ) -> YBaseDoc | None:
-        """Get a read-only view of the shared model for the matching document.
+        """Get a view of the shared model for the matching document.
 
-        The returned shared model is a fork, meaning that any changes made to it
-        will not be propagated to the shared model used by the application.
+        If `copy=True`, the returned shared model is a fork, meaning that any changes
+         made to it will not be propagated to the shared model used by the application.
         """
         file_id_manager = self.serverapp.web_app.settings["file_id_manager"]
         file_id = file_id_manager.index(path)

--- a/jupyter_collaboration/app.py
+++ b/jupyter_collaboration/app.py
@@ -140,6 +140,7 @@ class YDocExtension(ExtensionApp):
         path: str,
         content_type: Literal["notebook", "file"],
         file_format: Literal["json", "text"],
+        copy: bool = True,
     ) -> YBaseDoc | None:
         """Get a read-only view of the shared model for the matching document.
 
@@ -158,7 +159,15 @@ class YDocExtension(ExtensionApp):
             return None
 
         if isinstance(room, DocumentRoom):
-            return room._document
+            if copy:
+                update = room.ydoc.get_update()
+
+                fork_ydoc = Doc()
+                fork_ydoc.apply_update(update)
+
+                return YDOCS.get(content_type, YDOCS["file"])(fork_ydoc)
+            else:
+                return room._document
 
         return None
 

--- a/jupyter_collaboration/handlers.py
+++ b/jupyter_collaboration/handlers.py
@@ -26,6 +26,7 @@ from .utils import (
     LogLevel,
     MessageType,
     decode_file_path,
+    room_id_from_encoded_path,
 )
 from .websocketserver import JupyterWebsocketServer
 
@@ -74,7 +75,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
             await self._websocket_server.started.wait()
 
         # Get room
-        self._room_id: str = self.request.path.split("/")[-1]
+        self._room_id: str = room_id_from_encoded_path(self.request.path)
 
         async with self._room_lock(self._room_id):
             if self._websocket_server.room_exists(self._room_id):

--- a/jupyter_collaboration/utils.py
+++ b/jupyter_collaboration/utils.py
@@ -70,3 +70,8 @@ def encode_file_path(format: str, file_type: str, file_id: str) -> str:
             path (str): File path.
     """
     return f"{format}:{file_type}:{file_id}"
+
+
+def room_id_from_encoded_path(encoded_path: str) -> str:
+    """Transforms the encoded path into a stable room identifier."""
+    return encoded_path.split("/")[-1]

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -3,6 +3,8 @@
 
 from __future__ import annotations
 
+import pytest
+
 from jupyter_collaboration.stores import SQLiteYStore, TempFileYStore
 
 
@@ -61,9 +63,28 @@ def test_settings_should_change_ystore_class(jp_configurable_serverapp):
     assert settings["ystore_class"] == TempFileYStore
 
 
-async def test_get_document_file(rtc_create_file, jp_serverapp):
+@pytest.mark.parametrize("copy", [True, False])
+async def test_get_document_file(rtc_create_file, jp_serverapp, copy):
     path, content = await rtc_create_file("test.txt", "test", store=True)
     collaboration = jp_serverapp.web_app.settings["jupyter_collaboration"]
-    document = await collaboration.get_document(path=path, content_type="file", file_format="text")
+    document = await collaboration.get_document(
+        path=path, content_type="file", file_format="text", copy=copy
+    )
     assert document.get() == content == "test"
+    await collaboration.stop_extension()
+
+
+async def test_get_document_file_copy_is_independent(
+    rtc_create_file, jp_serverapp, rtc_fetch_session
+):
+    path, content = await rtc_create_file("test.txt", "test", store=True)
+    collaboration = jp_serverapp.web_app.settings["jupyter_collaboration"]
+    document = await collaboration.get_document(
+        path=path, content_type="file", file_format="text", copy=True
+    )
+    document.set("other")
+    fresh_copy = await collaboration.get_document(
+        path=path, content_type="file", file_format="text"
+    )
+    assert fresh_copy.get() == "test"
     await collaboration.stop_extension()

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -67,15 +67,3 @@ async def test_get_document_file(rtc_create_file, jp_serverapp):
     document = await collaboration.get_document(path=path, content_type="file", file_format="text")
     assert document.get() == content == "test"
     await collaboration.stop_extension()
-
-
-async def test_get_document_file_is_a_fork(rtc_create_file, jp_serverapp, rtc_fetch_session):
-    path, content = await rtc_create_file("test.txt", "test", store=True)
-    collaboration = jp_serverapp.web_app.settings["jupyter_collaboration"]
-    document = await collaboration.get_document(path=path, content_type="file", file_format="text")
-    document.set("other")
-    fresh_copy = await collaboration.get_document(
-        path=path, content_type="file", file_format="text"
-    )
-    assert fresh_copy.get() == "test"
-    await collaboration.stop_extension()


### PR DESCRIPTION
Closes https://github.com/jupyterlab/jupyter-collaboration/issues/270

Adds `get_document(path, content_type, file_format)` method to the `YDocExtension`.

The returned object is a fork of the original document, thus any modifications are not propagated back.