### PR TITLE
Workaround shutdown issue with `aiosqlite` for now

### DIFF
--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -62,6 +62,7 @@ async def test_room_concurrent_initialization(
 
 
 async def test_room_sequential_opening(
+    jp_serverapp,
     rtc_create_file,
     rtc_connect_doc_client,
 ):
@@ -81,3 +82,7 @@ async def test_room_sequential_opening(
     assert dt < 1
     dt = await connect(file_format, file_type, file_path)
     assert dt < 1
+
+    # workaround for a shutdown issue of aiosqlite, see
+    # https://github.com/jupyterlab/jupyter-collaboration/issues/252
+    await jp_serverapp.web_app.settings["jupyter_collaboration"].stop_extension()

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -41,6 +41,7 @@ async def test_dirty(
 
 
 async def test_room_concurrent_initialization(
+    jp_serverapp,
     rtc_create_file,
     rtc_connect_doc_client,
 ):
@@ -59,6 +60,10 @@ async def test_room_concurrent_initialization(
         tg.start_soon(connect, file_format, file_type, file_path)
     t1 = time()
     assert t1 - t0 < 0.5
+
+    # workaround for a shutdown issue of aiosqlite, see
+    # https://github.com/jupyterlab/jupyter-collaboration/issues/252
+    await jp_serverapp.web_app.settings["jupyter_collaboration"].stop_extension()
 
 
 async def test_room_sequential_opening(

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -40,6 +40,14 @@ async def test_dirty(
                 assert not jupyter_ydoc.dirty
 
 
+async def cleanup(jp_serverapp):
+    # workaround for a shutdown issue of aiosqlite, see
+    # https://github.com/jupyterlab/jupyter-collaboration/issues/252
+    await jp_serverapp.web_app.settings["jupyter_collaboration"].stop_extension()
+    # workaround `jupyter_server_fileid` manager accessing database on GC
+    del jp_serverapp.web_app.settings["file_id_manager"]
+
+
 async def test_room_concurrent_initialization(
     jp_serverapp,
     rtc_create_file,
@@ -61,9 +69,7 @@ async def test_room_concurrent_initialization(
     t1 = time()
     assert t1 - t0 < 0.5
 
-    # workaround for a shutdown issue of aiosqlite, see
-    # https://github.com/jupyterlab/jupyter-collaboration/issues/252
-    await jp_serverapp.web_app.settings["jupyter_collaboration"].stop_extension()
+    await cleanup(jp_serverapp)
 
 
 async def test_room_sequential_opening(
@@ -88,6 +94,4 @@ async def test_room_sequential_opening(
     dt = await connect(file_format, file_type, file_path)
     assert dt < 1
 
-    # workaround for a shutdown issue of aiosqlite, see
-    # https://github.com/jupyterlab/jupyter-collaboration/issues/252
-    await jp_serverapp.web_app.settings["jupyter_collaboration"].stop_extension()
+    await cleanup(jp_serverapp)


### PR DESCRIPTION
Addresses issue discussed in https://github.com/jupyterlab/jupyter-collaboration/issues/252 to help bring the CI green again.

The Windows tests are still failing though - are these indicative or Windows-specific bugs?