### PR TITLE
Only include `docprovider` packages in its sdist

### DIFF
--- a/projects/jupyter-docprovider/pyproject.toml
+++ b/projects/jupyter-docprovider/pyproject.toml
@@ -45,7 +45,8 @@ artifacts = ["jupyter_docprovider/labextension"]
 exclude = ["/.github", "/binder", "node_modules"]
 
 [tool.hatch.build.targets.sdist.force-include]
-"../../packages" = "packages"
+"../../packages/docprovider" = "packages/docprovider"
+"../../packages/docprovider-extension" = "packages/docprovider-extension"
 
 [tool.hatch.build.targets.wheel.shared-data]
 "jupyter_docprovider/labextension" = "share/jupyter/labextensions/@jupyter/docprovider-extension"


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab/jupyter-collaboration/pull/280.

Only include `docprovider` and `docprovider-extension` in sdist of `jupyter-docprovider` to reduce its size.