### PR TITLE
Rename the docprovider destination name to avoid conficts

### DIFF
--- a/projects/jupyter-docprovider/jupyter_docprovider/__init__.py
+++ b/projects/jupyter-docprovider/jupyter_docprovider/__init__.py
@@ -5,4 +5,4 @@ from ._version import __version__  # noqa
 
 
 def _jupyter_labextension_paths():
-    return [{"src": "labextension", "dest": "@jupyter/collaboration-extension"}]
+    return [{"src": "labextension", "dest": "@jupyter/docprovider-extension"}]


### PR DESCRIPTION
Fix the `docprovider` extension destination path, following https://github.com/jupyterlab/jupyter-collaboration/pull/280

Fixes https://github.com/jupyterlab/jupyter-collaboration/issues/283

We should probably add some tests (I don't even know how it passed)