### PR TITLE
Start Y Websocket Server earlier and make it resilient to crashes

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -70,9 +70,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         task.add_done_callback(self._background_tasks.discard)
 
     async def prepare(self):
-        if not self._websocket_server.started.is_set():
-            self.create_task(self._websocket_server.start())
-            await self._websocket_server.started.wait()
+        await self._websocket_server.started.wait()
 
         # Get room
         self._room_id: str = room_id_from_encoded_path(self.request.path)


### PR DESCRIPTION
This prevents the server locking we see in #290

This PR makes two critical changes:

1. Instead of starting the y-websocket server when the first YWebsocketHandler request is made, this PR starts the server in the startup sequence of the ExtensionApp. 
2. Handle exceptions in the ywebsocket server using the exception logging offered in https://github.com/jupyter-server/pycrdt-websocket/pull/31

This depends on this PR in Jupyter Server: https://github.com/jupyter-server/jupyter_server/pull/1417