### PR TITLE
Workaround for later initialization, recovers document_ttl

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -3,7 +3,7 @@ on:
   push:
     branches: ["main"]
   pull_request:
-
+  workflow_dispatch:
   schedule:
     - cron: "0 8 * * *"
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/stores.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/stores.py
@@ -30,3 +30,9 @@ class SQLiteYStore(LoggingConfigurable, _SQLiteYStore, metaclass=SQLiteYStoreMet
         help="""The document time-to-live in seconds. Defaults to None (document history is never
         cleared).""",
     )
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        # Class is instantiated later, so we need to set the document_ttl here
+        self.document_ttl = int(self.document_ttl) if self.document_ttl is not None else None
+      

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -62,13 +62,18 @@ def test_settings_should_change_ystore_class(jp_configurable_serverapp):
     assert settings["ystore_class"] == TempFileYStore
 
 
-def test_settings_should_change_document_ttl(jp_configurable_serverapp):
+async def test_document_ttl_from_settings(
+    rtc_create_SQLite_store, rtc_create_mock_document_room, jp_configurable_serverapp):
     argv = ["--SQLiteYStore.document_ttl=3600"]
 
     app = jp_configurable_serverapp(argv=argv)
-    settings = app.web_app.settings["jupyter_server_ydoc_config"]
 
-    assert settings["ystore_class"].document_ttl == 3600
+    id = "test-id"
+    content = "test_ttl"
+    store = await rtc_create_SQLite_store("file", id, content)
+    
+    assert store.document_ttl == 3600
+
 
 
 @pytest.mark.parametrize("copy", [True, False])

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -62,6 +62,15 @@ def test_settings_should_change_ystore_class(jp_configurable_serverapp):
     assert settings["ystore_class"] == TempFileYStore
 
 
+def test_settings_should_change_document_ttl(jp_configurable_serverapp):
+    argv = ["--SQLiteYStore.document_ttl=3600"]
+
+    app = jp_configurable_serverapp(argv=argv)
+    settings = app.web_app.settings["jupyter_server_ydoc_config"]
+
+    assert settings["ystore_class"].document_ttl == 3600
+
+
 @pytest.mark.parametrize("copy", [True, False])
 async def test_get_document_file(rtc_create_file, jp_serverapp, copy):
     path, content = await rtc_create_file("test.txt", "test", store=True)


### PR DESCRIPTION
This is a short fix for https://github.com/jupyterlab/jupyter-collaboration/issues/315. 

In the future this can be updated when the changed traitlets infrastructure is fully taken into account but for now this restores the `document_ttl` functionality and should have no negative side effects.
