### PR TITLE
Remove @jupyter/collaboration dependency from @jupyter/docprovider

### DIFF
--- a/packages/collaboration-extension/src/collaboration.ts
+++ b/packages/collaboration-extension/src/collaboration.ts
@@ -14,7 +14,10 @@ import {
   EditorExtensionRegistry,
   IEditorExtensionRegistry
 } from '@jupyterlab/codemirror';
-import { WebSocketAwarenessProvider } from '@jupyter/docprovider';
+import {
+  IGlobalAwareness,
+  WebSocketAwarenessProvider
+} from '@jupyter/docprovider';
 import { SidePanel, usersIcon } from '@jupyterlab/ui-components';
 import { URLExt } from '@jupyterlab/coreutils';
 import { ServerConnection } from '@jupyterlab/services';
@@ -27,7 +30,6 @@ import { IAwareness } from '@jupyter/ydoc';
 
 import {
   CollaboratorsPanel,
-  IGlobalAwareness,
   IUserMenu,
   remoteUserCursors,
   RendererUserMenu,

--- a/packages/collaboration/package.json
+++ b/packages/collaboration/package.json
@@ -41,7 +41,6 @@
   "dependencies": {
     "@codemirror/state": "^6.2.0",
     "@codemirror/view": "^6.7.0",
-    "@jupyter/docprovider": "^3.0.0-beta.0",
     "@jupyterlab/apputils": "^4.0.5",
     "@jupyterlab/coreutils": "^6.0.5",
     "@jupyterlab/docregistry": "^4.0.5",

--- a/packages/collaboration/src/tokens.ts
+++ b/packages/collaboration/src/tokens.ts
@@ -5,8 +5,6 @@ import type { Menu } from '@lumino/widgets';
 import { Token } from '@lumino/coreutils';
 import type { User } from '@jupyterlab/services';
 
-import { IAwareness } from '@jupyter/ydoc';
-
 /**
  * The user menu token.
  *
@@ -15,13 +13,6 @@ import { IAwareness } from '@jupyter/ydoc';
  */
 export const IUserMenu = new Token<IUserMenu>(
   '@jupyter/collaboration:IUserMenu'
-);
-
-/**
- * The global awareness token.
- */
-export const IGlobalAwareness = new Token<IAwareness>(
-  '@jupyter/collaboration:IGlobalAwareness'
 );
 
 /**

--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -53,7 +53,6 @@
     "watch:labextension": "jupyter labextension watch ."
   },
   "dependencies": {
-    "@jupyter/collaboration": "^3.0.0-beta.0",
     "@jupyter/docprovider": "^3.0.0-beta.0",
     "@jupyter/ydoc": "^2.0.0",
     "@jupyterlab/application": "^4.2.0",

--- a/packages/docprovider-extension/src/filebrowser.ts
+++ b/packages/docprovider-extension/src/filebrowser.ts
@@ -26,8 +26,11 @@ import { CommandRegistry } from '@lumino/commands';
 
 import { YFile, YNotebook } from '@jupyter/ydoc';
 
-import { IGlobalAwareness } from '@jupyter/collaboration';
-import { ICollaborativeDrive, YDrive } from '@jupyter/docprovider';
+import {
+  ICollaborativeDrive,
+  IGlobalAwareness,
+  YDrive
+} from '@jupyter/docprovider';
 import { Awareness } from 'y-protocols/awareness';
 
 /**

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { DocumentChange, YDocument } from '@jupyter/ydoc';
+import { DocumentChange, IAwareness, YDocument } from '@jupyter/ydoc';
 import { Contents } from '@jupyterlab/services';
 
 import { Token } from '@lumino/coreutils';
@@ -14,6 +14,13 @@ import { IChatMessage } from './awareness';
  */
 export const ICollaborativeDrive = new Token<ICollaborativeDrive>(
   '@jupyter/collaboration-extension:ICollaborativeDrive'
+);
+
+/**
+ * The global awareness token.
+ */
+export const IGlobalAwareness = new Token<IAwareness>(
+  '@jupyter/collaboration:IGlobalAwareness'
 );
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2116,7 +2116,6 @@ __metadata:
   dependencies:
     "@codemirror/state": ^6.2.0
     "@codemirror/view": ^6.7.0
-    "@jupyter/docprovider": ^3.0.0-beta.0
     "@jupyterlab/apputils": ^4.0.5
     "@jupyterlab/coreutils": ^6.0.5
     "@jupyterlab/docregistry": ^4.0.5
@@ -2139,7 +2138,6 @@ __metadata:
   version: 0.0.0-use.local
   resolution: "@jupyter/docprovider-extension@workspace:packages/docprovider-extension"
   dependencies:
-    "@jupyter/collaboration": ^3.0.0-beta.0
     "@jupyter/docprovider": ^3.0.0-beta.0
     "@jupyter/ydoc": ^2.0.0
     "@jupyterlab/application": ^4.2.0


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-collaboration/issues/330

This PR move the `IAwareness` token from *@jupyter/collaboration* package to *@jupyter/docpovider*, to fix a dependency issue.
It also remove a leftover dependency in *@jupyter/collaboration*.