### PR TITLE
Fix spurious "File Changed" dialog in JupyterLab 4.1+/Notebook 7.1+

### DIFF
--- a/packages/docprovider/src/ydrive.ts
+++ b/packages/docprovider/src/ydrive.ts
@@ -174,7 +174,6 @@ export class YDrive extends Drive implements ICollaborativeDrive {
       this._providers.set(key, provider);
 
       sharedModel.changed.connect(async (_, change) => {
-        // TODO: make use of the hash
         if (!change.stateChange) {
           return;
         }
@@ -192,29 +191,16 @@ export class YDrive extends Drive implements ICollaborativeDrive {
         const hashChange = hashChanges[0];
 
         // A change in hash signifies that a save occurred on the server-side
-        // (e.g. a collaborator performed the save) - we want notify the observers
-        // about this change so that they can store the new hash value.
-
+        // (e.g. a collaborator performed the save) - we want to notify the
+        // observers about this change so that they can store the new hash value.
         const model = await this.get(options.path, { content: false });
-        /*
+
         this._ydriveFileChanged.emit({
-          type: 'server-side-save',
-          newValue: {...model, hash: hashChange.newValue},
+          type: 'save',
+          newValue: { ...model, hash: hashChange.newValue },
           // we do not have the old model because it was discarded when server made the change,
           // we only have the old hash here (which may be empty if the file was newly created!)
-          oldValue: {hash: hashChange.oldValue}
-        });
-        */
-        // TODO: add handler for `server-side-save` in
-        // https://github.com/jupyterlab/jupyterlab/blob/dca1ec376c66038b8df7001d32cf058c70fcd717/packages/docregistry/src/context.ts#L410-L444
-        // For now, fake it:
-        // it happens that "rename" will perform the update of context's internal
-        // contentsModel (which we desire to solve the spurious "File Changed" dialog)
-        // even if file path has not changed.
-        this._ydriveFileChanged.emit({
-          type: 'rename',
-          newValue: { ...model, hash: hashChange.newValue },
-          oldValue: { ...model, hash: hashChange.oldValue }
+          oldValue: { hash: hashChange.oldValue }
         });
       });
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/loaders.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/loaders.py
@@ -117,7 +117,7 @@ class FileLoader:
             self.last_modified = model["last_modified"]
             return model
 
-    async def maybe_save_content(self, model: dict[str, Any]) -> None:
+    async def maybe_save_content(self, model: dict[str, Any]) -> dict[str, Any] | None:
         """
         Save the content of the file.
 
@@ -149,20 +149,34 @@ class FileLoader:
                 # otherwise it could corrupt the file
                 done_saving = asyncio.Event()
                 task = asyncio.create_task(self._save_content(model, done_saving))
+                saved_model = None
                 try:
-                    await asyncio.shield(task)
+                    saved_model = await asyncio.shield(task)
                 except asyncio.CancelledError:
                     pass
                 await done_saving.wait()
+                return saved_model
             else:
                 # file changed on disk, raise an error
                 self.last_modified = m["last_modified"]
                 raise OutOfBandChanges
 
-    async def _save_content(self, model: dict[str, Any], done_saving: asyncio.Event) -> None:
+    async def _save_content(
+        self, model: dict[str, Any], done_saving: asyncio.Event
+    ) -> dict[str, Any]:
         try:
             m = await ensure_async(self._contents_manager.save(model, self.path))
             self.last_modified = m["last_modified"]
+            # TODO, get rid of the extra `get` here once upstream issue:
+            # https://github.com/jupyter-server/jupyter_server/issues/1453 is resolved
+            model_with_hash = await ensure_async(
+                self._contents_manager.get(
+                    self.path,
+                    content=False,
+                    require_hash=True,  # TODO require version supporting hash
+                )
+            )
+            return {**m, "hash": model_with_hash["hash"]}
         finally:
             done_saving.set()
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/loaders.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/loaders.py
@@ -173,7 +173,7 @@ class FileLoader:
                 self._contents_manager.get(
                     self.path,
                     content=False,
-                    require_hash=True,  # TODO require version supporting hash
+                    require_hash=True,
                 )
             )
             return {**m, "hash": model_with_hash["hash"]}

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
@@ -271,7 +271,7 @@ class DocumentRoom(YRoom):
             await asyncio.sleep(self._save_delay)
 
             self.log.info("Saving the content from room %s", self._room_id)
-            await self._file.maybe_save_content(
+            saved_model = await self._file.maybe_save_content(
                 {
                     "format": self._file_format,
                     "type": self._file_type,
@@ -280,6 +280,11 @@ class DocumentRoom(YRoom):
             )
             async with self._update_lock:
                 self._document.dirty = False
+                if saved_model:
+                    self._document.hash = saved_model["hash"]
+                    # for now circumvent the public API, TODO remove before undrafting,
+                    # once https://github.com/jupyter-server/jupyter_ydoc/pull/262 is merged
+                    self._document._ystate["hash"] = saved_model["hash"]
 
             self._emit(LogLevel.INFO, "save", "Content saved.")
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
@@ -282,9 +282,6 @@ class DocumentRoom(YRoom):
                 self._document.dirty = False
                 if saved_model:
                     self._document.hash = saved_model["hash"]
-                    # for now circumvent the public API, TODO remove before undrafting,
-                    # once https://github.com/jupyter-server/jupyter_ydoc/pull/262 is merged
-                    self._document._ystate["hash"] = saved_model["hash"]
 
             self._emit(LogLevel.INFO, "save", "Content saved.")
 

--- a/projects/jupyter-server-ydoc/pyproject.toml
+++ b/projects/jupyter-server-ydoc/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
     { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
 dependencies = [
-    "jupyter_server>=2.4.0,<3.0.0",
+    "jupyter_server>=2.11.1,<3.0.0",
     "jupyter_ydoc>=2.0.0,<4.0.0",
     "pycrdt",
     "pycrdt-websocket>=0.14.0,<0.15.0",


### PR DESCRIPTION
- fixes https://github.com/jupyterlab/jupyter-collaboration/issues/312
- fixes https://github.com/jupyterlab/jupyter-collaboration/issues/313
- fixes https://github.com/jupyterlab/jupyter-collaboration/issues/317
- requires a PR to `jupyter_ydoc` to add `hash` setter https://github.com/jupyter-server/jupyter_ydoc/pull/262
- requires to set the hash on frontend; we can emit `fileChanged` signal from drive and this gets passed down to the context which stores the hash; this requires https://github.com/jupyterlab/jupyterlab/pull/16695