### PR TITLE
Register RTC content provider

### DIFF
--- a/packages/docprovider-extension/src/index.ts
+++ b/packages/docprovider-extension/src/index.ts
@@ -8,11 +8,8 @@
 import { JupyterFrontEndPlugin } from '@jupyterlab/application';
 
 import {
-  drive,
-  yfile,
-  ynotebook,
-  defaultFileBrowser,
   logger,
+  rtcContentProvider,
   statusBarTimeline
 } from './filebrowser';
 import { notebookCellExecutor } from './executor';
@@ -21,10 +18,7 @@ import { notebookCellExecutor } from './executor';
  * Export the plugins as default.
  */
 const plugins: JupyterFrontEndPlugin<any>[] = [
-  drive,
-  yfile,
-  ynotebook,
-  defaultFileBrowser,
+  rtcContentProvider,
   logger,
   notebookCellExecutor,
   statusBarTimeline

--- a/packages/docprovider/src/tokens.ts
+++ b/packages/docprovider/src/tokens.ts
@@ -1,7 +1,7 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { DocumentChange, IAwareness, YDocument } from '@jupyter/ydoc';
+import { IAwareness } from '@jupyter/ydoc';
 import { Contents } from '@jupyterlab/services';
 
 import { Token } from '@lumino/coreutils';
@@ -24,13 +24,6 @@ export const IGlobalAwareness = new Token<IAwareness>(
 );
 
 /**
- * A document factory for registering shared models
- */
-export type SharedDocumentFactory = (
-  options: Contents.ISharedFactoryOptions
-) => YDocument<DocumentChange>;
-
-/**
  * A Collaborative implementation for an `IDrive`, talking to the
  * server using the Jupyter REST API and a WebSocket connection.
  */
@@ -45,16 +38,6 @@ export interface ICollaborativeDrive extends Contents.IDrive {
  * Yjs sharedModel factory for real-time collaboration.
  */
 export interface ISharedModelFactory extends Contents.ISharedFactory {
-  /**
-   * Register a SharedDocumentFactory.
-   *
-   * @param type Document type
-   * @param factory Document factory
-   */
-  registerDocumentFactory(
-    type: Contents.ContentType,
-    factory: SharedDocumentFactory
-  ): void;
 }
 
 /**


### PR DESCRIPTION
Needs https://github.com/jupyterlab/jupyterlab/pull/16744.

This PR gets rid of the custom drive, and instead uses the default JupyterLab drive where it registers a content provider that uses the RTC protocol.