### PR TITLE
Remove the unused `ISettingRegistry` token from the file browser plugin

### DIFF
--- a/packages/docprovider-extension/src/filebrowser.ts
+++ b/packages/docprovider-extension/src/filebrowser.ts
@@ -239,12 +239,7 @@ export const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
   description: 'The default file browser factory provider',
   provides: IDefaultFileBrowser,
   requires: [ICollaborativeDrive, IFileBrowserFactory],
-  optional: [
-    IRouter,
-    JupyterFrontEnd.ITreeResolver,
-    ILabShell,
-    ITranslator
-  ],
+  optional: [IRouter, JupyterFrontEnd.ITreeResolver, ILabShell, ITranslator],
   activate: async (
     app: JupyterFrontEnd,
     drive: YDrive,

--- a/packages/docprovider-extension/src/filebrowser.ts
+++ b/packages/docprovider-extension/src/filebrowser.ts
@@ -243,7 +243,6 @@ export const defaultFileBrowser: JupyterFrontEndPlugin<IDefaultFileBrowser> = {
     IRouter,
     JupyterFrontEnd.ITreeResolver,
     ILabShell,
-    ISettingRegistry,
     ITranslator
   ],
   activate: async (


### PR DESCRIPTION
3.0.0b5 is broken due to this token.