### PR TITLE
Update jupyter_ydoc and pycrdt_websocket dependencies

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -286,31 +286,6 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         """
         message_type = message[0]
 
-        if message_type == YMessageType.AWARENESS:
-            # awareness
-            skip = False
-            changes = self.room.awareness.get_changes(message[1:])
-            added_users = changes["added"]
-            removed_users = changes["removed"]
-            for i, user in enumerate(added_users):
-                u = changes["states"][i]
-                if "user" in u:
-                    name = u["user"]["name"]
-                    self._websocket_server.connected_users[user] = name
-                    self.log.debug("Y user joined: %s", name)
-            for user in removed_users:
-                if user in self._websocket_server.connected_users:
-                    name = self._websocket_server.connected_users[user]
-                    del self._websocket_server.connected_users[user]
-                    self.log.debug("Y user left: %s", name)
-            # filter out message depending on changes
-            if skip:
-                self.log.debug(
-                    "Filtered out Y message of type: %s",
-                    YMessageType(message_type).name,
-                )
-                return skip
-
         if message_type == MessageType.CHAT:
             msg = message[2:].decode("utf-8")
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -8,7 +8,7 @@ import json
 import time
 import uuid
 from logging import Logger
-from typing import Any
+from typing import Any, Literal
 from uuid import uuid4
 
 from jupyter_server.auth import authorized
@@ -384,7 +384,9 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
                 self._emit(LogLevel.INFO, "clean", "Loader deleted.")
             del self._room_locks[self._room_id]
 
-    def _on_global_awareness_event(self, topic: str, changes: tuple[dict[str, Any], Any]) -> None:
+    def _on_global_awareness_event(
+        self, topic: Literal["change", "update"], changes: tuple[dict[str, Any], Any]
+    ) -> None:
         """
         Update the users when the global awareness changes.
 
@@ -392,7 +394,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
                 topic (str): `"update"` or `"change"` (`"change"` is triggered only if the states are modified).
                 changes (tuple[dict[str, Any], Any]): The changes and the origin of the changes.
         """
-        if type != "change":
+        if topic != "change":
             return
         added_users = changes[0]["added"]
         removed_users = changes[0]["removed"]

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -15,7 +15,7 @@ from jupyter_server.auth import authorized
 from jupyter_server.base.handlers import APIHandler, JupyterHandler
 from jupyter_server.utils import ensure_async
 from jupyter_ydoc import ydocs as YDOCS
-from pycrdt import Doc, UndoManager, YMessageType, write_var_uint
+from pycrdt import Doc, UndoManager, write_var_uint
 from pycrdt_websocket.websocket_server import YRoom
 from pycrdt_websocket.ystore import BaseYStore
 from tornado import web

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -383,14 +383,13 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
                 self._emit(LogLevel.INFO, "clean", "Loader deleted.")
             del self._room_locks[self._room_id]
 
-    def _on_global_awareness_event(self, type: str, changes: tuple[dict[str, Any], Any]) -> None:
+    def _on_global_awareness_event(self, topic: str, changes: tuple[dict[str, Any], Any]) -> None:
         """
         Update the users when the global awareness changes.
 
-
             Parameters:
-                type: 'update' or 'change' (change is triggered only if the states are modified)
-                changes: the changes
+                topic (str): `"update"` or `"change"` (`"change"` is triggered only if the states are modified).
+                changes (tuple[dict[str, Any], Any]): The changes and the origin of the changes.
         """
         if type != "change":
             return
@@ -404,8 +403,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
                 self.log.debug("Y user joined: %s", name)
         for user in removed_users:
             if user in self._websocket_server.connected_users:
-                name = self._websocket_server.connected_users[user]
-                del self._websocket_server.connected_users[user]
+                name = self._websocket_server.connected_users.pop(user)
                 self.log.debug("Y user left: %s", name)
 
     def check_origin(self, origin):

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -137,8 +137,9 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
                         exception_handler=exception_logger,
                     )
 
-                    # Listen for the changes in GlobalAwareness to update users
-                    self.room.awareness.observe(self._on_global_awareness_event)
+                    if self._room_id == "JupyterLab:globalAwareness":
+                        # Listen for the changes in GlobalAwareness to update users
+                        self.room.awareness.observe(self._on_global_awareness_event)
 
             try:
                 await self._websocket_server.start_room(self.room)

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
@@ -57,9 +57,6 @@ class DocumentRoom(YRoom):
         self._document.observe(self._on_document_change)
         self._file.observe(self.room_id, self._on_outofband_change, self._on_filepath_change)
 
-        # Listen for awareness changes
-        self.awareness.observe(self._on_awareness_change)
-
     @property
     def file_format(self) -> str:
         """Document file format."""
@@ -318,23 +315,6 @@ class DocumentRoom(YRoom):
             msg = f"Error saving file: {self._file.path}\n{e!r}"
             self.log.error(msg, exc_info=e)
             self._emit(LogLevel.ERROR, None, msg)
-
-    def _on_awareness_change(self, type: str, changes: tuple[dict[str, Any], Any]) -> None:
-        if type != "change":
-            return
-        added_users = changes[0]["added"]
-        removed_users = changes[0]["removed"]
-        for user in added_users:
-            u = self.awareness.states[user]
-            if "user" in u:
-                name = u["user"]["name"]
-                self._websocket_server.connected_users[user] = name
-                self.log.debug("Y user joined: %s", name)
-        for user in removed_users:
-            if user in self._websocket_server.connected_users:
-                name = self._websocket_server.connected_users[user]
-                del self._websocket_server.connected_users[user]
-                self.log.debug("Y user left: %s", name)
 
 
 class TransientRoom(YRoom):

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
@@ -319,12 +319,12 @@ class DocumentRoom(YRoom):
             self.log.error(msg, exc_info=e)
             self._emit(LogLevel.ERROR, None, msg)
 
-    def _on_awareness_change(self, type: str, changes: tuple[dict[str, Any], Any]):
+    def _on_awareness_change(self, type: str, changes: tuple[dict[str, Any], Any]) -> None:
         if type != "change":
             return
         added_users = changes[0]["added"]
         removed_users = changes[0]["removed"]
-        for i, user in enumerate(added_users):
+        for _, user in enumerate(added_users):
             u = self.awareness.states[user]
             if "user" in u:
                 name = u["user"]["name"]

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
@@ -324,7 +324,7 @@ class DocumentRoom(YRoom):
             return
         added_users = changes[0]["added"]
         removed_users = changes[0]["removed"]
-        for _, user in enumerate(added_users):
+        for user in added_users:
             u = self.awareness.states[user]
             if "user" in u:
                 name = u["user"]["name"]

--- a/projects/jupyter-server-ydoc/pyproject.toml
+++ b/projects/jupyter-server-ydoc/pyproject.toml
@@ -29,9 +29,9 @@ authors = [
 ]
 dependencies = [
     "jupyter_server>=2.11.1,<3.0.0",
-    "jupyter_ydoc>=2.0.0,<4.0.0",
+    "jupyter_ydoc>=2.1.2,<4.0.0",
     "pycrdt",
-    "pycrdt-websocket>=0.14.2,<0.15.0",
+    "pycrdt-websocket>=0.15.0,<0.16.0",
     "jupyter_events>=0.10.0",
     "jupyter_server_fileid>=0.7.0,<1",
     "jsonschema>=4.18.0"


### PR DESCRIPTION
This PR updates dependencies:
- `jupyter_ydoc >=2.1.2`
- `pycrdt_websocket >=0.15.0`
- indirectly `pycrdt >=0.10.1,<0.11.0`

These changes allow the use of document awareness on the server side, to handle states on server. 

- add the awareness to the `YDocument` (after https://github.com/jupyter-server/jupyter_ydoc/pull/277)
- this awareness is updated with the remote clients changes (https://github.com/jupyter-server/pycrdt-websocket/pull/76)
- the changes in its local state are broadcasted to remote clients (https://github.com/jupyter-server/jupyter_ydoc/pull/277)