### PR TITLE
Updates warning message on double file open

### DIFF
--- a/packages/docprovider-extension/src/filebrowser.ts
+++ b/packages/docprovider-extension/src/filebrowser.ts
@@ -46,8 +46,8 @@ namespace CommandIDs {
 const DOCUMENT_TIMELINE_URL = 'api/collaboration/timeline';
 
 const TWO_SESSIONS_WARNING =
-  'You have opened the file %1 with two separate views. ' +
-  'This is not supported. Please close one view; otherwise, ' +
+  'The file %1 has been opened with two different views. ' +
+  'This is not supported. Please close this view; otherwise, ' +
   'some of your edits may not be saved properly.';
 
 /**

--- a/packages/docprovider-extension/src/filebrowser.ts
+++ b/packages/docprovider-extension/src/filebrowser.ts
@@ -45,6 +45,11 @@ namespace CommandIDs {
 }
 const DOCUMENT_TIMELINE_URL = 'api/collaboration/timeline';
 
+const TWO_SESSIONS_WARNING =
+  'You have opened the file %1 twice in this session.\n' +
+  '\nThis is not supported. Please close one view; otherwise, ' +
+  'some of your edits may not be saved properly.';
+
 /**
  * The default collaborative drive provider.
  */
@@ -306,10 +311,7 @@ export const logger: JupyterFrontEndPlugin<void> = {
           if (emission.level === 'WARNING') {
             showDialog({
               title: trans.__('Warning'),
-              body: trans.__(
-                `Two collaborative sessions are accessing the file ${emission.path} simultaneously.
-                \nOpening the same file using different views simultaneously is not supported. Please, close one view; otherwise, you might lose some of your progress.`
-              ),
+              body: trans.__(TWO_SESSIONS_WARNING, emission.path),
               buttons: [Dialog.okButton()]
             });
           }
@@ -355,11 +357,7 @@ export const logger: JupyterFrontEndPlugin<void> = {
           if (emission.level === 'WARNING') {
             showDialog({
               title: trans.__('Warning'),
-              body: trans.__(
-                `Two collaborative sessions are accessing the file %1 simultaneously.
-                \nOpening a document with multiple views simultaneously is not supported. Please close one view; otherwise, you might lose some of your progress.`,
-                emission.path
-              ),
+              body: trans.__(TWO_SESSIONS_WARNING, emission.path),
               buttons: [Dialog.warnButton({ label: trans.__('Ok') })]
             });
           }

--- a/packages/docprovider-extension/src/filebrowser.ts
+++ b/packages/docprovider-extension/src/filebrowser.ts
@@ -46,7 +46,7 @@ namespace CommandIDs {
 const DOCUMENT_TIMELINE_URL = 'api/collaboration/timeline';
 
 const TWO_SESSIONS_WARNING =
-  'You have opened the file %1 twice in this session. ' +
+  'You have opened the file %1 with two separate views. ' +
   'This is not supported. Please close one view; otherwise, ' +
   'some of your edits may not be saved properly.';
 

--- a/packages/docprovider-extension/src/filebrowser.ts
+++ b/packages/docprovider-extension/src/filebrowser.ts
@@ -46,8 +46,8 @@ namespace CommandIDs {
 const DOCUMENT_TIMELINE_URL = 'api/collaboration/timeline';
 
 const TWO_SESSIONS_WARNING =
-  'You have opened the file %1 twice in this session.\n' +
-  '\nThis is not supported. Please close one view; otherwise, ' +
+  'You have opened the file %1 twice in this session. ' +
+  'This is not supported. Please close one view; otherwise, ' +
   'some of your edits may not be saved properly.';
 
 /**


### PR DESCRIPTION
If the same file is opened twice in the same JupyterLab session, in two different contexts, we had previously displayed a message reading:

> Two collaborative sessions are accessing the file (name) simultaneously. Opening a document with multiple views simultaneously is not supported. Please close one view; otherwise, you might lose some of your progress.

This change rewrites the message to:

> You have opened the file _(name)_ with two separate views. This is not supported. Please close one view; otherwise, some of your edits may not be saved properly.

This is intended to be clearer, and is intended to fix or mitigate #371. "Two collaborative sessions are accessing" is misleading; two **different** sessions can, by design, edit the same file. This warning should only appear when the user opens the file twice in **the same** session. In addition, "some of your progress" is misleading; because this warning appears on initial load, we can assume that the user hasn't made any edits yet.