### PR TITLE
Add `packages/collaborative-drive` to the typedoc config

### DIFF
--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,6 @@
 {
   "entryPointStrategy": "packages",
-  "entryPoints": ["packages/collaboration", "packages/docprovider"],
+  "entryPoints": ["packages/collaboration", "packages/collaborative-drive", "packages/docprovider"],
   "externalSymbolLinkMappings": {
     "@codemirror/state": {
       "Extension": "https://codemirror.net/docs/ref/#state.Extension"

--- a/typedoc.json
+++ b/typedoc.json
@@ -1,6 +1,10 @@
 {
   "entryPointStrategy": "packages",
-  "entryPoints": ["packages/collaboration", "packages/collaborative-drive", "packages/docprovider"],
+  "entryPoints": [
+    "packages/collaboration",
+    "packages/collaborative-drive",
+    "packages/docprovider"
+  ],
   "externalSymbolLinkMappings": {
     "@codemirror/state": {
       "Extension": "https://codemirror.net/docs/ref/#state.Extension"


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab/jupyter-collaboration/pull/353.

So it shows up in https://jupyterlab-realtime-collaboration.readthedocs.io/en/latest/api/index.html