### PR TITLE
Fix duplicate collaborator entries in collaboration panel

### DIFF
--- a/packages/collaboration/src/collaboratorspanel.tsx
+++ b/packages/collaboration/src/collaboratorspanel.tsx
@@ -98,14 +98,19 @@ export class CollaboratorsPanel extends Panel {
   private _onAwarenessChanged = () => {
     const state = this._awareness.getStates() as any;
     const collaborators: ICollaboratorAwareness[] = [];
-
+    const collaborators_keys: Set<string> = new Set();
     state.forEach((value: Partial<ICollaboratorAwareness>, key: any) => {
       if (
         this._currentUser.isReady &&
         value.user &&
         value.user.username !== this._currentUser.identity!.username
       ) {
-        collaborators.push(value as ICollaboratorAwareness);
+        const uniqueKey = `${value.user.username}-${value.current || 'no-current'}`;
+
+        if (!collaborators_keys.has(uniqueKey)) { 
+          collaborators.push(value as ICollaboratorAwareness);
+          collaborators_keys.add(uniqueKey);
+        }
       }
     });
     this._collaboratorsChanged.emit(collaborators);
@@ -132,9 +137,11 @@ export function CollaboratorsBody(props: {
 
   return (
     <div className={COLLABORATORS_LIST_CLASS}>
-      {collaborators.map((collaborator, i) => {
+      {collaborators.map((collaborator) => {
+        const uniqueKey = `${collaborator.user.username}-${collaborator.current || 'no-current'}`;
         return (
           <Collaborator
+            key={uniqueKey}
             collaborator={collaborator}
             fileopener={props.fileopener}
             docRegistry={props.docRegistry}

--- a/packages/collaboration/src/collaboratorspanel.tsx
+++ b/packages/collaboration/src/collaboratorspanel.tsx
@@ -97,8 +97,8 @@ export class CollaboratorsPanel extends Panel {
    */
   private _onAwarenessChanged = () => {
     const state = this._awareness.getStates() as any;
-    const collaborators: ICollaboratorAwareness[] = [];
-    const collaborators_keys: Set<string> = new Set();
+    const collaboratorsMap = new Map<string, ICollaboratorAwareness>();
+
     state.forEach((value: Partial<ICollaboratorAwareness>, key: any) => {
       if (
         this._currentUser.isReady &&
@@ -106,14 +106,13 @@ export class CollaboratorsPanel extends Panel {
         value.user.username !== this._currentUser.identity!.username
       ) {
         const uniqueKey = `${value.user.username}-${value.current || 'no-current'}`;
-
-        if (!collaborators_keys.has(uniqueKey)) { 
-          collaborators.push(value as ICollaboratorAwareness);
-          collaborators_keys.add(uniqueKey);
+        if (!collaboratorsMap.has(uniqueKey)) {
+          collaboratorsMap.set(uniqueKey, value as ICollaboratorAwareness);
         }
       }
     });
-    this._collaboratorsChanged.emit(collaborators);
+    // Convert map to array to maintain the same emit interface
+    this._collaboratorsChanged.emit(Array.from(collaboratorsMap.values()));
   };
   private _currentUser: User.IManager;
   private _awareness: Awareness;

--- a/packages/collaboration/src/collaboratorspanel.tsx
+++ b/packages/collaboration/src/collaboratorspanel.tsx
@@ -105,7 +105,9 @@ export class CollaboratorsPanel extends Panel {
         value.user &&
         value.user.username !== this._currentUser.identity!.username
       ) {
-        const uniqueKey = `${value.user.username}-${value.current || 'no-current'}`;
+        const uniqueKey = `${value.user.username}-${
+          value.current || 'no-current'
+        }`;
         if (!collaboratorsMap.has(uniqueKey)) {
           collaboratorsMap.set(uniqueKey, value as ICollaboratorAwareness);
         }
@@ -136,8 +138,10 @@ export function CollaboratorsBody(props: {
 
   return (
     <div className={COLLABORATORS_LIST_CLASS}>
-      {collaborators.map((collaborator) => {
-        const uniqueKey = `${collaborator.user.username}-${collaborator.current || 'no-current'}`;
+      {collaborators.map(collaborator => {
+        const uniqueKey = `${collaborator.user.username}-${
+          collaborator.current || 'no-current'
+        }`;
         return (
           <Collaborator
             key={uniqueKey}


### PR DESCRIPTION
## Problem
When the same user connects from multiple browsers, the collaborator panel may show duplicate entries even when they are viewing the same file. This causes unnecessary clutter and React key warnings.

## Solution
- Add deduplication logic in `_onAwarenessChanged` using a Set to track unique combinations of username and current file
- Only add a collaborator to the list if their unique key (username + current file) hasn't been seen before
- Use consistent unique keys in both the awareness change handler and React component rendering

## Changes
- Add `collaborators_keys` Set to track unique collaborator entries
- Create unique keys using username and current file path
- Filter out duplicate entries before adding to collaborators list
- Update React key prop to use the same unique key format

## Testing
1. Open the same notebook in multiple browser windows with the same user
2. Verify only one entry shows per unique (username, current file) combination
3. Check browser console - no more React key warnings