### PR TITLE
Pin jupyterlab at `>=4.4.0a2,<5.0.0` in `projects/jupyter-collaboration` package

### DIFF
--- a/projects/jupyter-collaboration/pyproject.toml
+++ b/projects/jupyter-collaboration/pyproject.toml
@@ -30,6 +30,7 @@ classifiers = [
 ]
 dynamic = ["version"]
 dependencies = [
+    "jupyterlab>=4.4.0a2,<5.0.0",
     "jupyter_collaboration_ui>=2.0.0.a0",
     "jupyter_docprovider>=2.0.0.a0",
     "jupyter_server_ydoc>=2.0.0.a0",

--- a/projects/jupyter-server-ydoc/pyproject.toml
+++ b/projects/jupyter-server-ydoc/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
     { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
 dependencies = [
-    "jupyterlab>=4.4.0,<5.0.0"
+    "jupyterlab>=4.4.0,<5.0.0",
     "jupyter_server>=2.11.1,<3.0.0",
     "jupyter_ydoc>=2.1.2,<4.0.0,!=3.0.0,!=3.0.1",
     "pycrdt",

--- a/projects/jupyter-server-ydoc/pyproject.toml
+++ b/projects/jupyter-server-ydoc/pyproject.toml
@@ -28,7 +28,6 @@ authors = [
     { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
 dependencies = [
-    "jupyterlab>=4.4.0,<5.0.0",
     "jupyter_server>=2.11.1,<3.0.0",
     "jupyter_ydoc>=2.1.2,<4.0.0,!=3.0.0,!=3.0.1",
     "pycrdt",

--- a/projects/jupyter-server-ydoc/pyproject.toml
+++ b/projects/jupyter-server-ydoc/pyproject.toml
@@ -28,6 +28,7 @@ authors = [
     { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
 dependencies = [
+    "jupyterlab>=4.4.0,<5.0.0"
     "jupyter_server>=2.11.1,<3.0.0",
     "jupyter_ydoc>=2.1.2,<4.0.0,!=3.0.0,!=3.0.1",
     "pycrdt",


### PR DESCRIPTION
Adds `jupyterlab` pin at `>=4.4.0a2,<5.0.0` in `projects/jupyter-collaboration` subpackage. This would introduce a way to specify which versions of jupyterlab current version of jupyter-collaboration is compatible with which would prevent RTC-jupyterlab version mismatch issues for new versions of jupyter-collaboration.

- Fixes #425

Testing:
1. Create new conda environment
2. Install jupyterlab<4.4.0a2 by running `pip install jupyterlab==4.2.0`
3. Clone this PR and install it locally by running `pip install -e .` from `projects/jupyter-collaboration`
4. Run `jupyter --version `, note updated `jupyterlab` version