### PR TITLE
Bump jupyter_server

### DIFF
--- a/projects/jupyter-server-ydoc/pyproject.toml
+++ b/projects/jupyter-server-ydoc/pyproject.toml
@@ -28,7 +28,7 @@ authors = [
     { name = "Jupyter Development Team", email = "jupyter@googlegroups.com" },
 ]
 dependencies = [
-    "jupyter_server>=2.11.1,<3.0.0",
+    "jupyter_server>=2.15.0,<3.0.0",
     "jupyter_ydoc>=2.1.2,<4.0.0,!=3.0.0,!=3.0.1",
     "pycrdt",
     "pycrdt-websocket>=0.15.0,<0.16.0",
@@ -42,7 +42,7 @@ dynamic = ["version"]
 test = [
     "coverage",
     "dirty-equals",
-    "jupyter_server[test]>=2.4.0",
+    "jupyter_server[test]>=2.15.0",
     "jupyter_server_fileid[test]",
     "pytest>=7.0",
     "pytest-cov",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -106,8 +106,6 @@ filterwarnings = [
     'ignore:Unclosed <MemoryObjectSendStream:ResourceWarning',
     # see https://github.com/python/cpython/issues/126259
     'ignore:unclosed database in <sqlite3.Connection object',
-    # remove when this is merged: https://github.com/jupyter-server/jupyter_server/pull/1481
-    'ignore:The `version` property of an event schema must be a string'
 ]
 
 [tool.mypy]


### PR DESCRIPTION
Bump `jupyter_server` to `2.15.0`, and remove the filter on warning in test, following the release of  https://github.com/jupyter-server/jupyter_server/commit/111e104f2a23bf72c9dd247e254940d6c714b1d0.