### PR TITLE
Add ui tests to showcase bug with saving of files with DOS line endings

### DIFF
--- a/ui-tests/README.md
+++ b/ui-tests/README.md
@@ -38,7 +38,7 @@ cd ..
 
 ```sh
 cd ./ui-tests
-jlpm playwright test
+jlpm run test
 ```
 
 Test results will be shown in the terminal. In case of any test failures, the test report

--- a/ui-tests/tests/file.spec.ts
+++ b/ui-tests/tests/file.spec.ts
@@ -84,7 +84,6 @@ test.describe('File Editing', () => {
 
       // Ensure we save the file
       // Due to the current "feature" of collab that it forces auto-save, we should not need to sent Ctrl+S but added so this doesn't break in future
-      console.log(await tab.getAttribute("class"));
       await expect(tab).toHaveClass(/jp-mod-dirty/);
       await page.keyboard.press("Control+S");
       await expect(tab).not.toHaveClass(/jp-mod-dirty/);

--- a/ui-tests/tests/file.spec.ts
+++ b/ui-tests/tests/file.spec.ts
@@ -1,0 +1,103 @@
+// Copyright (c) Jupyter Development Team.
+// Distributed under the terms of the Modified BSD License.
+
+import {
+  expect,
+  galata,
+  IJupyterLabPageFixture,
+  test
+} from '@jupyterlab/galata';
+import type { User } from '@jupyterlab/services';
+
+test.describe('File Editing', () => {
+  const exampleFile = 'example.py';
+  let guestPage: IJupyterLabPageFixture;
+
+  test.beforeEach(
+    async ({
+      page,
+      request,
+      baseURL,
+      browser,
+      tmpPath,
+      waitForApplication
+    }) => {
+      // Create a new client
+      const user: Partial<User.IUser> = {
+        identity: {
+          username: 'jovyan_2',
+          name: 'jovyan_2',
+          display_name: 'jovyan_2',
+          initials: 'JP',
+          color: 'var(--jp-collaborator-color2)'
+        }
+      };
+      const { page: newPage } = await galata.newPage({
+        baseURL: baseURL!,
+        browser,
+        mockUser: user,
+        tmpPath,
+        waitForApplication
+      });
+      guestPage = newPage;
+
+      await guestPage.evaluate(() => {
+        // Acknowledge any dialog
+        window.galataip.on('dialog', d => {
+          d?.resolve();
+        });
+      });
+    }
+  );
+
+  test.afterEach(async ({ page, request, tmpPath }) => {
+    const contents = galata.newContentsHelper(request);
+    await contents.deleteFile(`${tmpPath}/${exampleFile}`);
+    // Make sure to close the page to remove the client
+    // from the awareness
+    await guestPage.close();
+    await page.close();
+  });
+
+  [
+    { type: "normal", content: '# Example file\n# With normal/linux line endings\n\nname = ""\n\nprint(f"Hello {name}")' },
+    { type: "dos", content: '# Example file\r\n# With DOS (carriage return) line endings\r\n\r\nname = ""\r\n\r\nprint(f"Hello {name}")' },
+  ].forEach(({ type, content }) => {
+    test(`Edit a ${type} file`, async ({ page, request, tmpPath }) => {
+      const contents = galata.newContentsHelper(request);
+      await expect(contents.uploadContent(
+        content,
+        "text",
+        `${tmpPath}/${exampleFile}`
+      )).toBeTruthy();
+
+      await page.filebrowser.open(exampleFile);
+      const editor = page.locator('.cm-editor > .cm-scroller', { hasText: "Example" })
+      const tab = page.locator(`//li[contains(@title,"${exampleFile}") and @role="tab"]`)
+
+      // Enter text at `name = ""` to make `name = "Kuba"`
+      await editor.click();
+      await page.keyboard.press("ArrowUp");
+      await page.keyboard.press("ArrowUp");
+      await page.keyboard.press("ArrowLeft");
+      await page.keyboard.type("Kuba");
+
+      // Ensure we save the file
+      // Due to the current "feature" of collab that it forces auto-save, we should not need to sent Ctrl+S but added so this doesn't break in future
+      console.log(await tab.getAttribute("class"));
+      await expect(tab).toHaveClass(/jp-mod-dirty/);
+      await page.keyboard.press("Control+S");
+      await expect(tab).not.toHaveClass(/jp-mod-dirty/);
+
+      // This test should never fail, it's just testing that the above name insert completed succesfully
+      await expect(page.locator('.cm-editor > .cm-scroller', { hasText: "Example" })).toContainText('name = "Kuba"');
+
+      // Close and re-open the file
+      await page.locator(`div[title="Close ${exampleFile}"]`).click();
+      await page.filebrowser.open(exampleFile);
+
+      // The file should have saved successfully
+      await expect(page.locator('.cm-editor > .cm-scroller', { hasText: "Example" })).toContainText('name = "Kuba"');
+    });
+  });
+});


### PR DESCRIPTION
Added a failing test and a passing test to showcase how the collab save functionality is broken for dos files (files with dos line endings with a carriage return).

See issue (https://github.com/jupyterlab/jupyter-collaboration/issues/448) for full details.

Bug behaviour (video taken directly from UI test failure):
[f115b213aac2233742500c393c6e6033c6d27bfd.webm](https://github.com/user-attachments/assets/53a9521e-d59c-467e-9539-5238243ac0dc)


Also updated the UI readme so a new contributor can get started running tests straight away as the old README didn't work without a running jupyterlab instance manually (not documented in the README).