### PR TITLE
Bump min required `jupyter_events` version to 0.11

### DIFF
--- a/projects/jupyter-server-ydoc/pyproject.toml
+++ b/projects/jupyter-server-ydoc/pyproject.toml
@@ -32,7 +32,7 @@ dependencies = [
     "jupyter_ydoc>=2.1.2,<4.0.0,!=3.0.0,!=3.0.1",
     "pycrdt",
     "pycrdt-websocket>=0.15.0,<0.16.0",
-    "jupyter_events>=0.10.0",
+    "jupyter_events>=0.11.0",
     "jupyter_server_fileid>=0.7.0,<1",
     "jsonschema>=4.18.0"
 ]


### PR DESCRIPTION
Fixes failing `min-version` test as seen in https://github.com/jupyterlab/jupyter-collaboration/actions/runs/14006708068/job/39221681589

```
ERROR: Cannot install jupyterlab because these package versions have conflicting dependencies.

The conflict is caused by:
    jupyter-server 2.15.0 depends on jupyter-events>=0.11.0
    The user requested (constraint) jupyter-events==0.10.0
```

This test is now failing thanks to a new release of jupyterlab-maintenance-tools (https://github.com/jupyterlab/maintainer-tools/releases/tag/v0.28.0) which fixed the check in monorepos (https://github.com/jupyterlab/maintainer-tools/pull/250).