### PR TITLE
Skip saving non-writable files

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/loaders.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/loaders.py
@@ -153,6 +153,9 @@ class FileLoader:
                     path, format=model["format"], type=model["type"], content=False
                 )
             )
+            # Skip saving if file is not writable"
+            if not m["writable"]:
+                return None
 
             if self.last_modified == m["last_modified"]:
                 self._log.info("Saving file: %s", path)

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/loaders.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/loaders.py
@@ -153,7 +153,7 @@ class FileLoader:
                     path, format=model["format"], type=model["type"], content=False
                 )
             )
-            # Skip saving if file is not writable"
+            # Skip saving if file is not writable
             if not m["writable"]:
                 return None
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/pytest_plugin.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/pytest_plugin.py
@@ -271,14 +271,16 @@ def rtc_create_mock_document_room():
         last_modified: datetime | None = None,
         save_delay: float | None = None,
         store: SQLiteYStore | None = None,
-        writable: bool = False
+        writable: bool = False,
     ) -> tuple[FakeContentsManager, FileLoader, DocumentRoom]:
         paths = {id: path}
 
         if last_modified is None:
             cm = FakeContentsManager({"content": content, "writable": writable})
         else:
-            cm = FakeContentsManager({"last_modified": datetime.now(), "content": content, "writable": writable})
+            cm = FakeContentsManager(
+                {"last_modified": datetime.now(), "content": content, "writable": writable}
+            )
 
         loader = FileLoader(
             id,

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/pytest_plugin.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/pytest_plugin.py
@@ -271,13 +271,14 @@ def rtc_create_mock_document_room():
         last_modified: datetime | None = None,
         save_delay: float | None = None,
         store: SQLiteYStore | None = None,
+        writable: bool = False
     ) -> tuple[FakeContentsManager, FileLoader, DocumentRoom]:
         paths = {id: path}
 
         if last_modified is None:
-            cm = FakeContentsManager({"content": content})
+            cm = FakeContentsManager({"content": content, "writable": writable})
         else:
-            cm = FakeContentsManager({"last_modified": datetime.now(), "content": content})
+            cm = FakeContentsManager({"last_modified": datetime.now(), "content": content, "writable": writable})
 
         loader = FileLoader(
             id,

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -51,7 +51,7 @@ async def test_defined_save_delay_should_save_content_after_document_change(
     rtc_create_mock_document_room,
 ):
     content = "test"
-    cm, _, room = rtc_create_mock_document_room("test-id", "test.txt", content, save_delay=0.01)
+    cm, _, room = rtc_create_mock_document_room("test-id", "test.txt", content, save_delay=0.01, writable=True)
 
     await room.initialize()
     room._document.source = "Test 2"

--- a/tests/test_rooms.py
+++ b/tests/test_rooms.py
@@ -51,7 +51,9 @@ async def test_defined_save_delay_should_save_content_after_document_change(
     rtc_create_mock_document_room,
 ):
     content = "test"
-    cm, _, room = rtc_create_mock_document_room("test-id", "test.txt", content, save_delay=0.01, writable=True)
+    cm, _, room = rtc_create_mock_document_room(
+        "test-id", "test.txt", content, save_delay=0.01, writable=True
+    )
 
     await room.initialize()
     room._document.source = "Test 2"


### PR DESCRIPTION
## Description  
The `maybe_save_content` method in the `FileLoader` class attempted to save files without checking their permissions. If a file was **read-only**, this resulted in an error, which was logged in the frontend whenever changes were made to read-only files.
![Screenshot from 2025-04-01 18-06-40](https://github.com/user-attachments/assets/bb5d32ac-57a5-4e50-bb61-b809600ce0f8)

### Fix  
- Added a check to verify if the file is **writable** before attempting to save it; if the file is **read-only**, the save operation is skipped to prevent unnecessary errors.  
