### PR TITLE
Fix version pins in bump script

### DIFF
--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -109,7 +109,8 @@ def bump(force, skip_if_dirty, spec):
     dependencies = tomlkit.array()
     for key in sorted(project_pins):
         if key != metapackage.replace("-", "_"):
-            dependencies.add_line(key + ">=" + project_pins[key])
+            next_major = f"{parse_version(project_pins[key]).major + 1}"
+            dependencies.add_line(key + ">=" + project_pins[key] + ",<" + next_major)
     metapackage_toml.get("project").add("dependencies", dependencies.multiline(True))
     metapackage_toml_path.write_text(tomlkit.dumps(metapackage_toml))
 


### PR DESCRIPTION
While https://github.com/jupyterlab/jupyter-collaboration/pull/459 fixed the version pins, the bump script [reverted it](https://github.com/jupyterlab/jupyter-collaboration/commit/b4fc51bc462677ced63f1da58384ce2bd9fe1222#diff-2271c3877caf2a061a678f38ecb6d1351c52da6c446d4612a92cd701794c8fdfL33-L36) during release.

This PR fix the bump script to pin the project versions to `>=current_version,<next_major` instead of only `>=current_version`.
