### PR TITLE
Fix jupyterlab dependency dropped by the version bump script

### DIFF
--- a/projects/jupyter-collaboration/pyproject.toml
+++ b/projects/jupyter-collaboration/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "jupyter_collaboration_ui>=2.0.0",
     "jupyter_docprovider>=2.0.0",
     "jupyter_server_ydoc>=2.0.0",
+    "jupyterlab>=4.4.0a2,<5.0.0",
 ]
 
 [tool.hatch.version]

--- a/projects/jupyter-collaboration/pyproject.toml
+++ b/projects/jupyter-collaboration/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     "jupyter_collaboration_ui>=2.0.0",
     "jupyter_docprovider>=2.0.0",
     "jupyter_server_ydoc>=2.0.0",
-    "jupyterlab>=4.4.0a2,<5.0.0",
+    "jupyterlab>=4.4.0,<5.0.0",
 ]
 
 [tool.hatch.version]

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -7,7 +7,8 @@ from pathlib import Path
 import click
 import tomlkit
 from jupyter_releaser.util import get_version, run
-from pkg_resources import parse_version
+from pkg_resources import parse_version, Requirement
+
 
 LERNA_CMD = "jlpm run lerna version --no-push --force-publish --no-git-tag-version"
 
@@ -105,11 +106,18 @@ def bump(force, skip_if_dirty, spec):
     metapackage = "jupyter-collaboration"
     metapackage_toml_path = HERE / "projects" / metapackage / "pyproject.toml"
     metapackage_toml = tomlkit.parse(metapackage_toml_path.read_text())
+    old_dependencies = metapackage_toml.get("project").get("dependencies")
     metapackage_toml.get("project").remove("dependencies")
     dependencies = tomlkit.array()
     for key in sorted(project_pins):
         if key != metapackage.replace("-", "_"):
             dependencies.add_line(key + ">=" + project_pins[key])
+    # re-add other dependencies
+    for dependency in old_dependencies:
+        requirement = Requirement.parse(dependency)
+        print(requirement.project_name, project_pins)
+        if requirement.project_name.replace("-", "_") not in project_pins:
+            dependencies.add_line(dependency)
     metapackage_toml.get("project").add("dependencies", dependencies.multiline(True))
     metapackage_toml_path.write_text(tomlkit.dumps(metapackage_toml))
 

--- a/scripts/bump_version.py
+++ b/scripts/bump_version.py
@@ -115,7 +115,6 @@ def bump(force, skip_if_dirty, spec):
     # re-add other dependencies
     for dependency in old_dependencies:
         requirement = Requirement.parse(dependency)
-        print(requirement.project_name, project_pins)
         if requirement.project_name.replace("-", "_") not in project_pins:
             dependencies.add_line(dependency)
     metapackage_toml.get("project").add("dependencies", dependencies.multiline(True))


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-collaboration/issues/462

Should we yank 4.0.0 release?