### PR TITLE
Fix "Edit on GitHub" link in documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -58,7 +58,7 @@ html_theme_options = {
             "type": "local",
         }
     ],
-    "github_url": "https://github.com/jupyterlab/jupyter_collaboration",
+    "github_url": "https://github.com/jupyterlab/jupyter-collaboration",
     "use_edit_page_button": True,
     "show_toc_level": 1,
     "navbar_align": "left",
@@ -69,9 +69,10 @@ html_theme_options = {
 # Output for github to be used in links
 html_context = {
     "github_user": "jupyterlab",  # Username
-    "github_repo": "jupyter_collaboration",  # Repo name
+    "github_repo": "jupyter-collaboration",  # Repo name
     "github_version": "main",  # Version
-    "conf_py_path": "/docs/source/",  # Path in the checkout to the docs root
+    "doc_path": "docs/source",  # Path from repo root to the docs folder
+    "conf_py_path": "/docs/source",  # Path in the checkout to the docs root
 }
 
 myst_heading_anchors = 3


### PR DESCRIPTION
### Fixes #372 

Updated `html_context` in `conf.py` to set correct doc_path ('docs/source'), so the "Edit on GitHub" button links to the correct file path on GitHub.