### PR TITLE
Reset dirty state only when the file is saved

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
@@ -285,9 +285,9 @@ class DocumentRoom(YRoom):
                     "content": self._document.source,
                 }
             )
-            async with self._update_lock:
-                self._document.dirty = False
-                if saved_model:
+            if saved_model:
+                async with self._update_lock:
+                    self._document.dirty = False
                     self._document.hash = saved_model["hash"]
 
             self._emit(LogLevel.INFO, "save", "Content saved.")


### PR DESCRIPTION
After https://github.com/jupyterlab/jupyter-collaboration/pull/457 was merged, the current implementation resets the document’s dirty state to False even when the file isn't actually saved (e.g., when the file is read-only).

This PR fixes that behavior by resetting the dirty state only when the file is successfully saved. This prevents confusion in scenarios where changes appear to be saved in the frontend for read-only files, when they actually aren't saved.