### PR TITLE
Fix ystore imports after module moved to pycrdt.store

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -44,7 +44,7 @@ repos:
       - id: mypy
         exclude: "(^binder/jupyter_config\\.py$)|(^scripts/bump_version\\.py$)|(/setup\\.py$)"
         args: ["--config-file", "pyproject.toml"]
-        additional_dependencies: [tornado, pytest, pycrdt-websocket]
+        additional_dependencies: [tornado, pytest, pycrdt-websocket, pycrdt-store]
         stages: [manual]
 
   - repo: https://github.com/sirosen/check-jsonschema

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/app.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/app.py
@@ -10,7 +10,7 @@ from jupyter_server.extension.application import ExtensionApp
 from jupyter_ydoc import ydocs as YDOCS
 from jupyter_ydoc.ybasedoc import YBaseDoc
 from pycrdt import Doc
-from pycrdt_websocket.ystore import BaseYStore
+from pycrdt.store import BaseYStore
 from traitlets import Bool, Float, Type
 
 from .handlers import (

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -15,8 +15,8 @@ from jupyter_server.base.handlers import APIHandler, JupyterHandler
 from jupyter_server.utils import ensure_async
 from jupyter_ydoc import ydocs as YDOCS
 from pycrdt import Doc, UndoManager
-from pycrdt_websocket.yroom import YRoom
-from pycrdt_websocket.ystore import BaseYStore
+from pycrdt.websocket.yroom import YRoom
+from pycrdt.store import BaseYStore
 from tornado import web
 from tornado.websocket import WebSocketHandler
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/pytest_plugin.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/pytest_plugin.py
@@ -14,7 +14,7 @@ from jupyter_server_ydoc.loaders import FileLoader
 from jupyter_server_ydoc.rooms import DocumentRoom
 from jupyter_server_ydoc.stores import SQLiteYStore
 from jupyter_ydoc import YNotebook, YUnicode
-from pycrdt_websocket import WebsocketProvider
+from pycrdt.websocket import WebsocketProvider
 
 from .test_utils import (
     FakeContentsManager,

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
@@ -9,8 +9,8 @@ from typing import Any, Callable
 
 from jupyter_events import EventLogger
 from jupyter_ydoc import ydocs as YDOCS
-from pycrdt_websocket.yroom import YRoom
-from pycrdt_websocket.ystore import BaseYStore, YDocNotFound
+from pycrdt.websocket.yroom import YRoom
+from pycrdt.store import BaseYStore, YDocNotFound
 
 from .loaders import FileLoader
 from .utils import JUPYTER_COLLABORATION_EVENTS_URI, LogLevel, OutOfBandChanges

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/stores.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/stores.py
@@ -1,8 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from pycrdt_websocket.ystore import SQLiteYStore as _SQLiteYStore
-from pycrdt_websocket.ystore import TempFileYStore as _TempFileYStore
+from pycrdt.store import SQLiteYStore as _SQLiteYStore
+from pycrdt.store import TempFileYStore as _TempFileYStore
 from traitlets import Int, Unicode
 from traitlets.config import LoggingConfigurable
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/websocketserver.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/websocketserver.py
@@ -7,10 +7,10 @@ import asyncio
 from logging import Logger
 from typing import Any, Callable
 
-from pycrdt_websocket.websocket import Websocket
-from pycrdt_websocket.websocket_server import WebsocketServer
-from pycrdt_websocket.yroom import YRoom
-from pycrdt_websocket.ystore import BaseYStore
+from pycrdt.websocket import Websocket
+from pycrdt.websocket.websocket_server import WebsocketServer
+from pycrdt.websocket.yroom import YRoom
+from pycrdt.store import BaseYStore
 
 
 class RoomNotFound(LookupError):

--- a/projects/jupyter-server-ydoc/pyproject.toml
+++ b/projects/jupyter-server-ydoc/pyproject.toml
@@ -32,6 +32,7 @@ dependencies = [
     "jupyter_ydoc>=2.1.2,<4.0.0,!=3.0.0,!=3.0.1",
     "pycrdt",
     "pycrdt-websocket>=0.15.0,<0.16.0",
+    "pycrdt-store >=0.1.0,<0.2.0",
     "jupyter_events>=0.11.0",
     "jupyter_server_fileid>=0.7.0,<1",
     "jsonschema>=4.18.0"

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -12,7 +12,7 @@ else:
 import pytest
 from anyio import create_task_group, sleep
 from jupyter_server_ydoc.test_utils import Websocket
-from pycrdt_websocket import WebsocketProvider
+from pycrdt.websocket import WebsocketProvider
 
 jupyter_ydocs = {ep.name: ep.load() for ep in entry_points(group="jupyter_ydoc")}
 

--- a/tests/test_handlers.py
+++ b/tests/test_handlers.py
@@ -12,7 +12,7 @@ from jupyter_events.logger import EventLogger
 from jupyter_server_ydoc.test_utils import Websocket
 from jupyter_ydoc import YUnicode
 from pycrdt import Text
-from pycrdt_websocket import WebsocketProvider
+from pycrdt.websocket import WebsocketProvider
 
 
 async def test_session_handler_should_create_session_id(


### PR DESCRIPTION
This PR updates the imports for `YStore` and `websocket` to reflect their new location in the `pycrdt.store` and `pycrdt.websocket` module, after **YStore** being moved from **pycrdt_websocket** to https://github.com/y-crdt/pycrdt-store in https://github.com/y-crdt/pycrdt-websocket/pull/123