### PR TITLE
Add configurables to control ystore.db history and cleanup frequency

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/stores.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/stores.py
@@ -41,7 +41,6 @@ class SQLiteYStore(LoggingConfigurable, _SQLiteYStore, metaclass=SQLiteYStoreMet
         config=True,
         help="""The document time-to-live in seconds. Deprecated in favor of 'squash_after_inactivity_of'.
         Defaults to None (document history is never cleared).""",
-
     )
 
     squash_history_older_than = Int(


### PR DESCRIPTION
## References https://github.com/jupyterlab/jupyter-collaboration/issues/430

### Description

This PR introduces two new configurables to `SQLiteYStore` class which are introduced in https://github.com/y-crdt/pycrdt-store/pull/2:

- `squash_history_older_than`: Maximum age (in seconds) of document history to retain in the YStore. Older entries are pruned. Defaults to None (no pruning).
- `squash_no_more_often_than`: Minimum interval (in seconds) between automatic cleanup operations. Defaults to 60 seconds.

These options provide better control over the size of `ystore.db`, which can grow significantly over time.
