### PR TITLE
Fix confirmation on manual saving

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
@@ -280,6 +280,7 @@ class DocumentRoom(YRoom):
         self._saving_document = asyncio.create_task(
             self._maybe_save_document(self._saving_document)
         )
+        return self._saving_document
 
     async def _maybe_save_document(self, saving_document: asyncio.Task | None) -> None:
         """


### PR DESCRIPTION
### References

Fixes #485 and addresses https://github.com/jupyterlab/jupyterlab/pull/17508#pullrequestreview-2863834659.

### Code changes

In response to the raw `save` message on websocket the server now sends a raw message with a JSON string containing:

```ts
{
  'response-to': 'save';
  'status': 'success' | 'skipped' | 'failed';
}
```

The choice of a JSON structure over a simple `status` string is because:
- there are other raw messages being broadcast from the server, we need to distinguish ours somehow
- in the future we may want to include `hash` in the successful response to avoid an extra round trip, which we currently do by consecutively calling `this.get(localPath, fetchOptions)`.

The `RtcContentProvider.save` methods now waits for the response from the server, potentially throwing an error if server returns a failed or skipped status which then indicates that saving failed in the UI.

### User-facing changes

Previously (in `4.1.0rc0`) when saving a document manually (e.g. by pressing <kbd>Ctrl</kbd> + <kbd>S</kbd>) errors were ignored and status bar was incorrectly showing "saving completed" as soon as saving started, even when it was still in progress.

With this PR:
- the errors on backend are propagated to frontend
- the saving status is correctly reflected as in progress/completed depending on server reply