### PR TITLE
Document the breaking change in 4.0 in the changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -134,7 +134,7 @@ No merged PRs
 > [!IMPORTANT]
 > This version requires migration from `ICollaborativeDrive` to `ICollaborativeContentProvider` token for access to shared factory and forks:
 >
-> 
+>
 > ```diff
 > - import { ICollaborativeDrive } from '@jupyter/collaborative-drive';
 > + import { ICollaborativeContentProvider } from '@jupyter/collaborative-drive';


### PR DESCRIPTION
This should have been included earlier as per review.