### PR TITLE
Fix handling of `hubHost`

### DIFF
--- a/packages/collaboration/src/sharedlink.ts
+++ b/packages/collaboration/src/sharedlink.ts
@@ -134,12 +134,11 @@ export async function showSharedLinkDialog({
     serverOwner = PageConfig.getOption('hubServerUser');
     serverName = PageConfig.getOption('hubServerName');
     // Prepare the Hub API URL
-    const protocol = window.location.protocol;
-    const hostname =
-      PageConfig.getOption('hubHost') || window.location.hostname;
-    const port = window.location.port;
+    // hubHost is the full Origin (`proto://hostname:port`)
+    // or an empty string, making hubApiUrl an absolute path on the current origin
+    const hubHost = PageConfig.getOption('hubHost') || '';
     const prefix = PageConfig.getOption('hubPrefix');
-    hubApiUrl = `${protocol}//${hostname}:${port}${prefix}api`;
+    hubApiUrl = `${hubHost}${prefix}api`;
     // Check Hub version for share compatibility (>= 5.0)
     const response = await fetch(hubApiUrl, {
       // A GET request on base API url returns the Hub version

--- a/ui-tests/tests/hub-share.spec.ts
+++ b/ui-tests/tests/hub-share.spec.ts
@@ -15,7 +15,7 @@ test('should open JupyterHub sharing dialog', async ({ page }) => {
     document.body.dataset['hubUser'] = 'jovyan';
     document.body.dataset['hubServerUser'] = 'jovyan';
     document.body.dataset['hubServerName'] = 'my-server';
-    document.body.dataset['hubHost'] = 'localhost';
+    document.body.dataset['hubHost'] = '';
     document.body.dataset['hubPrefix'] = '/hub/';
   });
 


### PR DESCRIPTION
hubHost is either an empty string or full `proto://hostname[:port]` string, not a hostname

hub api url should prepend hubHost as-is, so it is either an absolute path (most cases) or a full URL (hubHost defined, subdomains in use).

closes https://github.com/jupyterhub/jupyterhub/issues/5133