### PR TITLE
Add npmjs.com to ignored links in test workflow

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -256,7 +256,7 @@ jobs:
       - uses: jupyterlab/maintainer-tools/.github/actions/base-setup@v1
       - uses: jupyterlab/maintainer-tools/.github/actions/check-links@v1
         with:
-          ignore_links: "../api/*.* ./api/* .*/images/[\\w-]+.png https://docs.github.com/en/.* https://github.com/.* https://mybinder.org/v2/gh/jupyterlab/jupyter_collaboration/.*"
+          ignore_links: "../api/*.* ./api/* .*/images/[\\w-]+.png https://docs.github.com/en/.* https://github.com/.* https://mybinder.org/v2/gh/jupyterlab/jupyter_collaboration/.* https://www.npmjs.com.*"
 
   ui_tests:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Mirrors https://github.com/jupyterlab/jupyterlab/pull/17915, the failing check was noted in https://github.com/jupyterlab/jupyter-collaboration/pull/511