### PR TITLE
fix: clean up background tasks on close

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/websocketserver.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/websocketserver.py
@@ -63,17 +63,17 @@ class JupyterWebsocketServer(WebsocketServer):
         # prevent hanging stop process - it also requires some thinking about
         # should the ystore write action be cancelled; I guess not as it could
         # results in corrupted data.
-        # room_tasks = list()
-        # for name, room in list(self.rooms.items()):
-        #     for task in room.background_tasks:
-        #         task.cancel()  # FIXME should be upstreamed
-        #         room_tasks.append(task)
-        # if room_tasks:
-        #     _, pending = await asyncio.wait(room_tasks, timeout=3)
-        #     if pending:
-        #         msg = f"{len(pending)} room task(s) are pending."
-        #         self.log.warning(msg)
-        #         self.log.debug("Pending tasks: %r", pending)
+        room_tasks = list()
+        for name, room in list(self.rooms.items()):
+            for task in room.background_tasks:
+                task.cancel()  # FIXME should be upstreamed
+                room_tasks.append(task)
+        if room_tasks:
+            _, pending = await asyncio.wait(room_tasks, timeout=3)
+            if pending:
+                msg = f"{len(pending)} room task(s) are pending."
+                self.log.warning(msg)
+                self.log.debug("Pending tasks: %r", pending)
 
         await self.stop()
         tasks = []


### PR DESCRIPTION
This PR attempts to close #503 and fix #161 by cleaning up background tasks upon closure of the websocket. I'm not sure if this fits into the wider design space for resource management, but it does fix "hang on shutdown" on my system.