### PR TITLE
Enable `TempFileYStore` to work with Jupyter Lab

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/stores.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/stores.py
@@ -7,7 +7,11 @@ from traitlets import Int, Unicode
 from traitlets.config import LoggingConfigurable
 
 
-class TempFileYStore(_TempFileYStore):
+class TempFileYStoreMetaclass(type(LoggingConfigurable), type(_TempFileYStore)):  # type: ignore
+    pass
+
+
+class TempFileYStore(LoggingConfigurable, _TempFileYStore, metaclass=TempFileYStoreMetaclass):
     prefix_dir = "jupyter_ystore_"
 
 


### PR DESCRIPTION
## Fixes #483 

This PR updates `TempFileYStore` so it can be used via command-line configuration.

The class now:

- Inherits from `LoggingConfigurable`. (Config argument now gets passed here).
- Uses a combined metaclass just like `SQLiteYStore`

With this change, `TempFileYStore` behaves consistently like `SQLiteYStore` when selected from the CLI.