### PR TITLE
Fix tests hanging on CI due to pytest configured to turn warnings into errors

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/stores.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/stores.py
@@ -27,10 +27,17 @@ class SQLiteYStore(LoggingConfigurable, _SQLiteYStore, metaclass=SQLiteYStoreMet
         directory.""",
     )
 
-    document_ttl = Int(
+    squash_after_inactivity_of = Int(
         None,
         allow_none=True,
         config=True,
         help="""The document time-to-live in seconds. Defaults to None (document history is never
         cleared).""",
+    )
+    document_ttl = Int(
+        None,
+        allow_none=True,
+        config=True,
+        help="""The document time-to-live in seconds. Deprecated in favor of 'squash_after_inactivity_of'.
+        Defaults to None (document history is never cleared).""",
     )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -97,6 +97,8 @@ filterwarnings = [
     "module:make_current is deprecated:DeprecationWarning",
     "module:clear_current is deprecated:DeprecationWarning",
     "module:There is no current event loop:DeprecationWarning",
+    # From pycrdt-store - document_ttl is deprecated in favor of squash_after_inactivity_of
+    "ignore:`document_ttl` is deprecated:DeprecationWarning",
     #
     "module:Jupyter is migrating its paths to use standard platformdirs:DeprecationWarning",
     # In PyPy/Cython: see https://github.com/yaml/pyyaml/issues/688

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -74,7 +74,23 @@ async def test_document_ttl_from_settings(rtc_create_mock_document_room, jp_conf
     rtc_create_SQLite_store = rtc_create_SQLite_store_factory(app)
     store = await rtc_create_SQLite_store("file", id, content)
 
-    assert store.document_ttl == 3600
+    # document_ttl is deprecated and mapped to squash_after_inactivity_of
+    assert store.squash_after_inactivity_of == 3600
+
+
+async def test_squash_after_inactivity_of_from_settings(
+    rtc_create_mock_document_room, jp_configurable_serverapp
+):
+    argv = ["--SQLiteYStore.squash_after_inactivity_of=3600"]
+
+    app = jp_configurable_serverapp(argv=argv)
+
+    id = "test-id"
+    content = "test_ttl"
+    rtc_create_SQLite_store = rtc_create_SQLite_store_factory(app)
+    store = await rtc_create_SQLite_store("file", id, content)
+
+    assert store.squash_after_inactivity_of == 3600
 
 
 @pytest.mark.parametrize("copy", [True, False])


### PR DESCRIPTION
Fixes #530

- do not treat deprecation warning as error in tests
- add traitlet for `squash_after_inactivity_of` (renamed from `document_ttl`)