### PR TITLE
Disambiguate log messages

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -440,8 +440,8 @@ class DocSessionHandler(APIHandler):
     auth_resource = "contents"
 
     @web.authenticated
-    @authorized
-    async def put(self, path: str):
+    @authorized  # type: ignore[misc]
+    async def put(self, path: str) -> asyncio.Future[Any]:
         """
         Creates a new session for a given document or returns an existing one.
         """


### PR DESCRIPTION
Two log messages are identical; even if technically you can update the logger to display the file and line number, I think it is better to have slightly different log messages so you can follow what is heppening.