### PR TITLE
Fix getting document_version

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -239,7 +239,12 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
             # Close the connection if the document session expired
             session_id = self.get_query_argument("sessionId", "")
             root_dir = self.settings.get("server_root_dir", os.getcwd())
-            document_version = getattr(self.room._document, "version", None)
+            version_attr = getattr(self.room._document, "version", None)
+
+            if callable(version_attr):
+                document_version = version_attr()
+            else:
+                document_version = version_attr
 
             # Persist the current session so future reconnects can validate it
             await save_current_session(


### PR DESCRIPTION
The latest release of jupyter-collaboration broke JupyterGIS: See https://github.com/geojupyter/jupytergis/issues/1230

This PR seems to fix it.

<img width="2514" height="1399" alt="Screenshot From 2026-04-03 10-09-51" src="https://github.com/user-attachments/assets/61e493d0-e013-415d-8b9a-b173bb99c4a9" />
