### PR TITLE
Add create argument to get_document API

### DIFF
--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/app.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/app.py
@@ -3,8 +3,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections import defaultdict
 from functools import partial
-from typing import Literal
+from typing import Literal, cast
 
 from jupyter_server.extension.application import ExtensionApp
 from jupyter_ydoc import ydocs as YDOCS
@@ -27,6 +28,7 @@ from .utils import (
     AWARENESS_EVENTS_SCHEMA_PATH,
     EVENTS_SCHEMA_PATH,
     FORK_EVENTS_SCHEMA_PATH,
+    decode_file_path,
     encode_file_path,
     room_id_from_encoded_path,
 )
@@ -91,6 +93,8 @@ class YDocExtension(ExtensionApp):
         model.""",
     )
 
+    _room_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
+
     def initialize(self):
         super().initialize()
         self.serverapp.event_logger.register_event_schema(EVENTS_SCHEMA_PATH)
@@ -153,6 +157,7 @@ class YDocExtension(ExtensionApp):
                         "file_loaders": self.file_loaders,
                         "ystore_class": ystore_class,
                         "ywebsocket_server": self.ywebsocket_server,
+                        "room_locks": self._room_locks,
                     },
                 ),
                 (r"/api/collaboration/session/(.*)", DocSessionHandler),
@@ -174,6 +179,44 @@ class YDocExtension(ExtensionApp):
             ]
         )
 
+    async def _create_room(self, room_id: str) -> DocumentRoom:
+        """Create a new document room, initialize it, and register it."""
+        file_format_str, file_type, file_id = decode_file_path(room_id)
+        file_format = cast(Literal["json", "text"], file_format_str)
+        updates_file_path = f".{file_type}:{file_id}.y"
+        ystore = self.ystore_class(
+            path=updates_file_path,
+            log=self.log,
+        )
+        room = DocumentRoom(
+            room_id,
+            file_format,
+            file_type,
+            self.file_loaders[file_id],
+            self.serverapp.event_logger,
+            ystore,
+            self.log,
+            exception_handler=exception_logger,
+            save_delay=self.document_save_delay,
+        )
+        await room.initialize()
+        try:
+            await self.ywebsocket_server.start_room(room)
+            self.ywebsocket_server.add_room(room_id, room)
+            self.log.info(f"Created and started room: {room_id}")
+        except Exception as e:
+            self.log.error("Room %s failed to start on websocket server", room_id)
+            await room.stop()
+            self.log.info("Room %s deleted", room_id)
+            file = self.file_loaders[file_id]
+            if file.number_of_subscriptions == 0 or (
+                file.number_of_subscriptions == 1 and room_id in file._subscriptions
+            ):
+                self.log.info("Deleting file %s", file.path)
+                await self.file_loaders.remove(file_id)
+            raise e
+        return room
+
     async def get_document(
         self: YDocExtension,
         *,
@@ -182,6 +225,7 @@ class YDocExtension(ExtensionApp):
         file_format: Literal["json", "text"] | None = None,
         room_id: str | None = None,
         copy: bool = True,
+        create: bool = False,
     ) -> YBaseDoc | None:
         """Get a view of the shared model for the matching document.
 
@@ -190,6 +234,8 @@ class YDocExtension(ExtensionApp):
 
         If `copy=True`, the returned shared model is a fork, meaning that any changes
          made to it will not be propagated to the shared model used by the application.
+
+        If `create=True`, the room will be created if it doesn't exist.
         """
         error_msg = (
             "You need to provide either a ``room_id`` or the ``path``, "
@@ -210,10 +256,17 @@ class YDocExtension(ExtensionApp):
         else:
             room_id = room_id
 
-        try:
-            room = await self.ywebsocket_server.get_room(room_id)
-        except RoomNotFound:
-            return None
+        if not self.ywebsocket_server.started.is_set():
+            asyncio.create_task(self.ywebsocket_server.start())
+            await self.ywebsocket_server.started.wait()
+        async with self._room_locks[room_id]:
+            try:
+                room = await self.ywebsocket_server.get_room(room_id)
+            except RoomNotFound:
+                if not create:
+                    return None
+
+                room = await self._create_room(room_id)
 
         if isinstance(room, DocumentRoom):
             if copy:

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -67,7 +67,6 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
 
     _message_queue: asyncio.Queue[Any]
     _background_tasks: set[asyncio.Task]
-    _room_locks: dict[str, asyncio.Lock] = {}
     _session_file_lock = asyncio.Lock()
 
     def _room_lock(self, room_id: str) -> asyncio.Lock:
@@ -179,6 +178,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         ywebsocket_server: JupyterWebsocketServer,
         file_loaders: FileLoaderMapping,
         ystore_class: type[BaseYStore],
+        room_locks: dict[str, asyncio.Lock] | None = None,
         document_cleanup_delay: float | None = 60.0,
         document_save_delay: float | None = 1.0,
     ) -> None:
@@ -193,6 +193,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
         self._message_queue = asyncio.Queue()
         self._room_id = ""
         self.room = None  # type:ignore
+        self._room_locks = room_locks if room_locks is not None else {}
 
     @property
     def path(self):

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -104,6 +104,24 @@ async def test_get_document_file(rtc_create_file, jp_serverapp, copy):
     await collaboration.stop_extension()
 
 
+async def test_get_document_create_room(rtc_create_file, jp_serverapp):
+    path, content = await rtc_create_file("test.txt", "test", index=True)
+    collaboration = jp_serverapp.web_app.settings["jupyter_server_ydoc"]
+    # Document doesn't exist initially
+    document_before = await collaboration.get_document(
+        path=path, content_type="file", file_format="text", create=False
+    )
+    assert document_before is None
+
+    document_after = await collaboration.get_document(
+        path=path, content_type="file", file_format="text", create=True
+    )
+    # Verify document was created and has correct content
+    assert document_after is not None
+    assert document_after.get() == content == "test"
+    await collaboration.stop_extension()
+
+
 @pytest.mark.parametrize("copy", [True, False])
 async def test_get_document_notebook(rtc_create_notebook, jp_serverapp, copy):
     nb = nbformat.v4.new_notebook(


### PR DESCRIPTION
## Fixes #328

### Description
Adds a `create` parameter to `get_document()` so that a document room is created if it does not already exist. This enables other extensions to obtain a document for server-side operations (e.g. execution) even when no collaborative session is open.

Based on #489 by @Darshan808, incorporating review feedback from @krassowski and @davidbrochart:
- Room locks are shared between `YDocExtension` and `YDocWebSocketHandler` via `defaultdict(asyncio.Lock)` to prevent race conditions during concurrent room creation.
- Room creation logic is extracted into `_create_room()` helper for clarity.

### Changes
- **`app.py`**: New `_create_room()` helper; `get_document()` gains `create: bool = False` parameter; `_room_locks` shared with handlers.
- **`handlers.py`**: `_room_locks` moved from class-level to instance-level, received via `initialize()` for backward compatibility.
- **`test_app.py`**: New `test_get_document_create_room` test.