### PR TITLE
Require Python 3.10, update classifiers

### DIFF
--- a/projects/jupyter-collaboration-ui/pyproject.toml
+++ b/projects/jupyter-collaboration-ui/pyproject.toml
@@ -9,7 +9,7 @@ requires = ["hatchling>=1.4.0", "jupyterlab>=4.0.0"]
 name = "jupyter-collaboration-ui"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 description = "JupyterLab/Jupyter Notebook 7+ extension providing user interface integration for real time collaboration"
 classifiers = [
     "Intended Audience :: Developers",
@@ -17,11 +17,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
     "Framework :: Jupyter :: JupyterLab :: 4",

--- a/projects/jupyter-collaboration/pyproject.toml
+++ b/projects/jupyter-collaboration/pyproject.toml
@@ -9,7 +9,7 @@ requires = ["hatchling>=1.4.0"]
 name = "jupyter-collaboration"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 description = "JupyterLab/Jupyter Notebook 7+ Real Time Collaboration extension (metapackage)"
 classifiers = [
     "Intended Audience :: Developers",
@@ -17,11 +17,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
     "Framework :: Jupyter :: JupyterLab :: 4",

--- a/projects/jupyter-docprovider/pyproject.toml
+++ b/projects/jupyter-docprovider/pyproject.toml
@@ -9,7 +9,7 @@ requires = ["hatchling>=1.4.0", "jupyterlab>=4.0.0"]
 name = "jupyter-docprovider"
 readme = "README.md"
 license = { file = "LICENSE" }
-requires-python = ">=3.8"
+requires-python = ">=3.10"
 description = "JupyterLab/Jupyter Notebook 7+ extension integrating collaborative shared models."
 classifiers = [
     "Intended Audience :: Developers",
@@ -17,11 +17,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Jupyter",
     "Framework :: Jupyter :: JupyterLab",
     "Framework :: Jupyter :: JupyterLab :: 4",

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/__init__.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/__init__.py
@@ -1,11 +1,11 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-from typing import Any, Dict, List
+from typing import Any
 
 from ._version import __version__  # noqa
 from .app import YDocExtension
 
 
-def _jupyter_server_extension_points() -> List[Dict[str, Any]]:
+def _jupyter_server_extension_points() -> list[dict[str, Any]]:
     return [{"module": "jupyter_server_ydoc", "app": YDocExtension}]

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/loaders.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/loaders.py
@@ -4,10 +4,11 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable, Coroutine
 from http import HTTPStatus
 from logging import Logger, getLogger
 from time import time
-from typing import Any, Callable, Coroutine
+from typing import Any
 
 from jupyter_server.services.contents.manager import (
     AsyncContentsManager,

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/rooms.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from logging import Logger
-from typing import Any, Callable
+from typing import Any
 
 from jupyter_events import EventLogger
 from jupyter_ydoc import ydocs as YDOCS
@@ -123,9 +124,7 @@ class DocumentRoom(YRoom):
                     self._emit(
                         LogLevel.INFO,
                         "load",
-                        "Content loaded from the store {}".format(
-                            self.ystore.__class__.__qualname__
-                        ),
+                        f"Content loaded from the store {self.ystore.__class__.__qualname__}",
                     )
                     self.log.info(
                         "Content in room %s loaded from the ystore %s",

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/utils.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/utils.py
@@ -7,7 +7,6 @@ import uuid
 from datetime import datetime, timezone
 from enum import Enum, IntEnum
 from pathlib import Path
-from typing import Tuple
 
 from ._version import __version__  # noqa
 
@@ -51,7 +50,7 @@ class WriteError(Exception):
     pass
 
 
-def decode_file_path(path: str) -> Tuple[str, str, str]:
+def decode_file_path(path: str) -> tuple[str, str, str]:
     """
     Decodes a file path. The file path is composed by the format,
     content type, and path or file id separated by ':'.
@@ -60,7 +59,7 @@ def decode_file_path(path: str) -> Tuple[str, str, str]:
             path (str): File path.
 
         Returns:
-            components (Tuple[str, str, str]): A tuple with the format,
+            components (tuple[str, str, str]): A tuple with the format,
                 content type, and path or file id.
     """
     format, file_type, file_id = path.split(":", 2)
@@ -115,7 +114,7 @@ def _load_previous_sessions(root_dir: str) -> dict:
                 if isinstance(value, dict):
                     clean_sessions[str(key)] = value
             return clean_sessions
-        except (json.JSONDecodeError, IOError, UnicodeDecodeError):
+        except (OSError, json.JSONDecodeError, UnicodeDecodeError):
             return {}
     return {}
 
@@ -146,7 +145,7 @@ async def save_current_session(
             del sessions[oldest_key]
         try:
             store_path.write_text(json.dumps(sessions, indent=2))
-        except IOError:
+        except OSError:
             pass
 
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/websocketserver.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/websocketserver.py
@@ -4,8 +4,9 @@
 from __future__ import annotations
 
 import asyncio
+from collections.abc import Callable
 from logging import Logger
-from typing import Any, Callable
+from typing import Any
 
 from pycrdt import Channel
 from pycrdt.store import BaseYStore

--- a/projects/jupyter-server-ydoc/pyproject.toml
+++ b/projects/jupyter-server-ydoc/pyproject.toml
@@ -17,11 +17,11 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "License :: OSI Approved :: BSD License",
     "Programming Language :: Python",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
     "Framework :: Jupyter"
 ]
 authors = [
@@ -55,7 +55,6 @@ test = [
     "pytest-cov",
     "anyio",
     "httpx-ws >=0.9.0",
-    "importlib_metadata >=4.8.3; python_version<'3.10'",
 ]
 
 [tool.hatch.version]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,10 +39,11 @@ docs = [
 
 [tool.ruff]
 line-length = 100
+target-version = "py310"
 exclude = [".github", "binder", "*.ipynb"]
 
 [tool.ruff.lint]
-extend-select = ["E", "I"]
+extend-select = ["E", "I", "UP"]
 
 [tool.hatch.version]
 source = "nodejs"

--- a/scripts/dev_install.py
+++ b/scripts/dev_install.py
@@ -3,10 +3,9 @@
 
 import subprocess
 from pathlib import Path
-from typing import Optional
 
 
-def execute(cmd: str, cwd: Optional[Path] = None) -> None:
+def execute(cmd: str, cwd: Path | None = None) -> None:
     subprocess.run(cmd.split(" "), check=True, cwd=cwd)
 
 

--- a/tests/test_documents.py
+++ b/tests/test_documents.py
@@ -1,13 +1,8 @@
 # Copyright (c) Jupyter Development Team.
 # Distributed under the terms of the Modified BSD License.
 
-import sys
+from importlib.metadata import entry_points
 from time import time
-
-if sys.version_info < (3, 10):
-    from importlib_metadata import entry_points
-else:
-    from importlib.metadata import entry_points
 
 import pytest
 from anyio import create_task_group, sleep


### PR DESCRIPTION
Minor maintenance check since Python 3.8 and 3.9 are EOL, and update classifiers.