### PR TITLE
Depend on `IDocumentManager` instead of fetching settings directly

### DIFF
--- a/packages/docprovider-extension/package.json
+++ b/packages/docprovider-extension/package.json
@@ -58,6 +58,7 @@
     "@jupyter/ydoc": "^2.1.3 || ^3.0.0",
     "@jupyterlab/application": "^4.5.0",
     "@jupyterlab/apputils": "^4.5.0",
+    "@jupyterlab/docmanager": "^4.5.0",
     "@jupyterlab/docregistry": "^4.5.0",
     "@jupyterlab/filebrowser": "^4.5.0",
     "@jupyterlab/fileeditor": "^4.5.0",

--- a/packages/docprovider-extension/src/filebrowser.ts
+++ b/packages/docprovider-extension/src/filebrowser.ts
@@ -14,6 +14,7 @@ import { Widget } from '@lumino/widgets';
 import { IStatusBar } from '@jupyterlab/statusbar';
 import { ContentsManager } from '@jupyterlab/services';
 
+import { IDocumentManager } from '@jupyterlab/docmanager';
 import {
   IEditorTracker,
   IEditorWidgetFactory,
@@ -55,13 +56,13 @@ export const rtcContentProvider: JupyterFrontEndPlugin<ICollaborativeContentProv
     description: 'The RTC content provider',
     provides: ICollaborativeContentProvider,
     requires: [ITranslator],
-    optional: [IGlobalAwareness, ISettingRegistry],
-    activate: async (
+    optional: [IGlobalAwareness, IDocumentManager],
+    activate: (
       app: JupyterFrontEnd,
       translator: ITranslator,
       globalAwareness: Awareness | null,
-      settingRegistry: ISettingRegistry | null
-    ): Promise<ICollaborativeContentProvider> => {
+      documentManager: IDocumentManager | null
+    ): ICollaborativeContentProvider => {
       const trans = translator.load('jupyter_collaboration');
       const defaultDrive = (app.serviceManager.contents as ContentsManager)
         .defaultDrive;
@@ -76,17 +77,13 @@ export const rtcContentProvider: JupyterFrontEndPlugin<ICollaborativeContentProv
           'Cannot initialize content provider: no content provider registry.'
         );
       }
-      const docmanagerSettings = settingRegistry
-        ? await settingRegistry.load('@jupyterlab/docmanager-extension:plugin')
-        : null;
-
       const rtcContentProvider = new RtcContentProvider({
         currentDrive: defaultDrive,
         serverSettings: defaultDrive.serverSettings,
         user: app.serviceManager.user,
         trans,
         globalAwareness,
-        docmanagerSettings,
+        documentManager,
         fileChanged: defaultDrive.fileChanged
       });
       registry.register('rtc', rtcContentProvider);

--- a/packages/docprovider/package.json
+++ b/packages/docprovider/package.json
@@ -46,6 +46,7 @@
     "@jupyterlab/apputils": "^4.5.0",
     "@jupyterlab/cells": "^4.5.0",
     "@jupyterlab/coreutils": "^6.5.0",
+    "@jupyterlab/docmanager": "^4.5.0",
     "@jupyterlab/notebook": "^4.5.0",
     "@jupyterlab/services": "^7.5.0",
     "@jupyterlab/translation": "^4.5.0",

--- a/packages/docprovider/src/ydrive.ts
+++ b/packages/docprovider/src/ydrive.ts
@@ -3,6 +3,7 @@
 
 import { IChangedArgs, PageConfig } from '@jupyterlab/coreutils';
 import { IDocumentManager } from '@jupyterlab/docmanager';
+import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import { TranslationBundle } from '@jupyterlab/translation';
 import {
   Contents,
@@ -48,7 +49,12 @@ namespace RtcContentProvider {
     trans: TranslationBundle;
     globalAwareness: Awareness | null;
     serverSettings: ServerConnection.ISettings;
-    documentManager: IDocumentManager | null;
+    documentManager?: IDocumentManager | null;
+    /**
+     * @deprecated Pass `documentManager` instead. Kept for backwards
+     * compatibility; will be removed in a future major release.
+     */
+    docmanagerSettings?: ISettingRegistry.ISettings | null;
     currentDrive: Contents.IDrive;
     fileChanged?: ISignal<Contents.IDrive, Contents.IChangedArgs>;
   }
@@ -63,7 +69,7 @@ export class RtcContentProvider implements IContentProvider {
     this._currentDrive = options.currentDrive;
     this.sharedModelFactory = new SharedModelFactory(this._onCreate);
     this._providers = new Map<string, WebSocketProvider>();
-    this._documentManager = options.documentManager;
+    this._documentManager = options.documentManager ?? null;
     this._driveFileChanged = options.fileChanged;
   }
 

--- a/packages/docprovider/src/ydrive.ts
+++ b/packages/docprovider/src/ydrive.ts
@@ -1,7 +1,8 @@
 // Copyright (c) Jupyter Development Team.
 // Distributed under the terms of the Modified BSD License.
 
-import { PageConfig } from '@jupyterlab/coreutils';
+import { IChangedArgs, PageConfig } from '@jupyterlab/coreutils';
+import { IDocumentManager } from '@jupyterlab/docmanager';
 import { TranslationBundle } from '@jupyterlab/translation';
 import {
   Contents,
@@ -26,7 +27,6 @@ import {
   ISharedModelFactory
 } from '@jupyter/collaborative-drive';
 import { Awareness } from 'y-protocols/awareness';
-import { ISettingRegistry } from '@jupyterlab/settingregistry';
 import * as decoding from 'lib0/decoding';
 import * as encoding from 'lib0/encoding';
 
@@ -48,7 +48,7 @@ namespace RtcContentProvider {
     trans: TranslationBundle;
     globalAwareness: Awareness | null;
     serverSettings: ServerConnection.ISettings;
-    docmanagerSettings: ISettingRegistry.ISettings | null;
+    documentManager: IDocumentManager | null;
     currentDrive: Contents.IDrive;
     fileChanged?: ISignal<Contents.IDrive, Contents.IChangedArgs>;
   }
@@ -63,7 +63,7 @@ export class RtcContentProvider implements IContentProvider {
     this._currentDrive = options.currentDrive;
     this.sharedModelFactory = new SharedModelFactory(this._onCreate);
     this._providers = new Map<string, WebSocketProvider>();
-    this._docmanagerSettings = options.docmanagerSettings;
+    this._documentManager = options.documentManager;
     this._driveFileChanged = options.fileChanged;
   }
 
@@ -234,16 +234,26 @@ export class RtcContentProvider implements IContentProvider {
       return;
     }
     // Set initial autosave value, used to determine backend autosave (default: true)
-    const autosave =
-      (this._docmanagerSettings?.composite?.['autosave'] as boolean) ?? true;
+    sharedModel.awareness.setLocalStateField(
+      'autosave',
+      this._documentManager?.autosave ?? true
+    );
 
-    sharedModel.awareness.setLocalStateField('autosave', autosave);
-
-    // Watch for changes in settings
-    this._docmanagerSettings?.changed.connect(() => {
-      const newAutosave =
-        (this._docmanagerSettings?.composite?.['autosave'] as boolean) ?? true;
-      sharedModel.awareness.setLocalStateField('autosave', newAutosave);
+    // Watch for autosave changes on the document manager.
+    const handleStateChanged = (
+      _: IDocumentManager,
+      args: IChangedArgs<any>
+    ) => {
+      if (args.name === 'autosave') {
+        sharedModel.awareness.setLocalStateField(
+          'autosave',
+          this._documentManager?.autosave ?? true
+        );
+      }
+    };
+    this._documentManager?.stateChanged.connect(handleStateChanged);
+    sharedModel.disposed.connect(() => {
+      this._documentManager?.stateChanged.disconnect(handleStateChanged);
     });
 
     try {
@@ -425,7 +435,7 @@ export class RtcContentProvider implements IContentProvider {
   // This is for listening to `Drive.fileChanged` signal
   private _driveFileChanged?: ISignal<Contents.IDrive, Contents.IChangedArgs>;
   private _serverSettings: ServerConnection.ISettings;
-  private _docmanagerSettings: ISettingRegistry.ISettings | null;
+  private _documentManager: IDocumentManager | null;
 }
 
 /**

--- a/packages/docprovider/src/ydrive.ts
+++ b/packages/docprovider/src/ydrive.ts
@@ -50,13 +50,15 @@ namespace RtcContentProvider {
     globalAwareness: Awareness | null;
     serverSettings: ServerConnection.ISettings;
     documentManager?: IDocumentManager | null;
-    /**
-     * @deprecated Pass `documentManager` instead. Kept for backwards
-     * compatibility; will be removed in a future major release.
-     */
-    docmanagerSettings?: ISettingRegistry.ISettings | null;
     currentDrive: Contents.IDrive;
     fileChanged?: ISignal<Contents.IDrive, Contents.IChangedArgs>;
+    /**
+     * @deprecated Pass `documentManager` instead. Used as a fallback when
+     * `documentManager` is not provided. Will be removed in a future major
+     * release.
+     * @see {@link IOptions.documentManager}
+     */
+    docmanagerSettings?: ISettingRegistry.ISettings | null;
   }
 }
 
@@ -70,6 +72,7 @@ export class RtcContentProvider implements IContentProvider {
     this.sharedModelFactory = new SharedModelFactory(this._onCreate);
     this._providers = new Map<string, WebSocketProvider>();
     this._documentManager = options.documentManager ?? null;
+    this._docmanagerSettings = options.docmanagerSettings ?? null;
     this._driveFileChanged = options.fileChanged;
   }
 
@@ -240,27 +243,41 @@ export class RtcContentProvider implements IContentProvider {
       return;
     }
     // Set initial autosave value, used to determine backend autosave (default: true)
-    sharedModel.awareness.setLocalStateField(
-      'autosave',
-      this._documentManager?.autosave ?? true
-    );
-
-    // Watch for autosave changes on the document manager.
-    const handleStateChanged = (
-      _: IDocumentManager,
-      args: IChangedArgs<any>
-    ) => {
-      if (args.name === 'autosave') {
-        sharedModel.awareness.setLocalStateField(
-          'autosave',
-          this._documentManager?.autosave ?? true
-        );
+    const getAutosave = (): boolean => {
+      if (this._documentManager) {
+        return this._documentManager.autosave ?? true;
       }
+      return (
+        (this._docmanagerSettings?.composite?.['autosave'] as boolean) ?? true
+      );
     };
-    this._documentManager?.stateChanged.connect(handleStateChanged);
-    sharedModel.disposed.connect(() => {
-      this._documentManager?.stateChanged.disconnect(handleStateChanged);
-    });
+
+    sharedModel.awareness.setLocalStateField('autosave', getAutosave());
+
+    if (this._documentManager) {
+      // Watch for autosave changes on the document manager.
+      const handleStateChanged = (
+        _: IDocumentManager,
+        args: IChangedArgs<any>
+      ) => {
+        if (args.name === 'autosave') {
+          sharedModel.awareness.setLocalStateField('autosave', getAutosave());
+        }
+      };
+      this._documentManager.stateChanged.connect(handleStateChanged);
+      sharedModel.disposed.connect(() => {
+        this._documentManager?.stateChanged.disconnect(handleStateChanged);
+      });
+    } else if (this._docmanagerSettings) {
+      // Fall back to watching the deprecated docmanager settings.
+      const handleSettingsChanged = () => {
+        sharedModel.awareness.setLocalStateField('autosave', getAutosave());
+      };
+      this._docmanagerSettings.changed.connect(handleSettingsChanged);
+      sharedModel.disposed.connect(() => {
+        this._docmanagerSettings?.changed.disconnect(handleSettingsChanged);
+      });
+    }
 
     try {
       const provider = new WebSocketProvider({
@@ -442,6 +459,7 @@ export class RtcContentProvider implements IContentProvider {
   private _driveFileChanged?: ISignal<Contents.IDrive, Contents.IChangedArgs>;
   private _serverSettings: ServerConnection.ISettings;
   private _documentManager: IDocumentManager | null;
+  private _docmanagerSettings: ISettingRegistry.ISettings | null;
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2167,6 +2167,7 @@ __metadata:
     "@jupyterlab/application": ^4.5.0
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/builder": ^4.5.0
+    "@jupyterlab/docmanager": ^4.5.0
     "@jupyterlab/docregistry": ^4.5.0
     "@jupyterlab/filebrowser": ^4.5.0
     "@jupyterlab/fileeditor": ^4.5.0
@@ -2194,6 +2195,7 @@ __metadata:
     "@jupyterlab/apputils": ^4.5.0
     "@jupyterlab/cells": ^4.5.0
     "@jupyterlab/coreutils": ^6.5.0
+    "@jupyterlab/docmanager": ^4.5.0
     "@jupyterlab/notebook": ^4.5.0
     "@jupyterlab/services": ^7.5.0
     "@jupyterlab/testing": ^4.5.0


### PR DESCRIPTION
Fixes https://github.com/jupyterlab/jupyter-collaboration/issues/573

Before the content provider plugin in `jupyter-docprovider` was fetching the settings for the core `@jupyterlab/docmanager-extension:plugin` directly. 

The transformer for that plugin id is registered inside the JupyterLab plugin with that same id, during its own activate: https://github.com/jupyterlab/jupyterlab/blob/8152d62832af21a85c483fae5662566afd9e4d1e/packages/docmanager-extension/src/index.tsx#L360

However when `jupyter-collaboration-ui` is not installed, it seems likely that the plugin loading the settings directly was activating earlier, before `@jupyterlab/docmanager-extension:plugin` had time to define its transform.

Which ends up hitting this code path: https://github.com/jupyterlab/jupyterlab/blob/8152d62832af21a85c483fae5662566afd9e4d1e/packages/settingregistry/src/settingregistry.ts#L682-L690

Also the settings were fetched directly to get some values already exposed via `IDocumentManager`.
