### PR TITLE
Rename check release upload artifact

### DIFF
--- a/.github/workflows/check-release.yml
+++ b/.github/workflows/check-release.yml
@@ -26,6 +26,6 @@ jobs:
       - name: Upload Distributions
         uses: actions/upload-artifact@v4
         with:
-          name: jupyter-releaser-dist-${{ github.run_number }}
+          name: jupyter-collaboration-dist-${{ github.run_number }}
           path: |
             .jupyter_releaser_checkout/dist


### PR DESCRIPTION
Makes it easier to know which project they refer to when downloading the artifacts locally.