### PR TITLE
Configurable `session_store_path`

### DIFF
--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -25,6 +25,13 @@ looses connection and goes offline for a while. You should never have to touch i
 fine to just ignore it, including in your version control system (don't commit this file). If
 you happen to delete it, there shouldn't be any serious consequence either.
 
+A second file, `collaboration_sessions.json`, is created inside a `.jupyter` directory under
+that same launch directory. It records recent collaboration session IDs so the backend can
+detect when a client is reconnecting after a server restart or version change, and prompt for
+a reload when the session can no longer be resumed safely. Like the YStore database, it is
+safe to ignore in version control and safe to delete (clients will simply be asked to reload
+on next connect).
+
 There are a number of settings that you can change:
 
 ```bash
@@ -46,6 +53,15 @@ jupyter lab --YDocExtension.document_cleanup_delay=100
 
 # The YStore class to use for storing Y updates (default: JupyterSQLiteYStore).
 jupyter lab --YDocExtension.ystore_class=pycrdt.store.TempFileYStore
+
+# Relocate the YStore SQLite database (default: '.jupyter_ystore.db' in the launch directory).
+# Useful when the launch directory is read-only, under version control, or shared between users.
+jupyter lab --SQLiteYStore.db_path=/path/to/ystore.db
+
+# Relocate the collaboration session store
+# (default: '<server_root_dir>/.jupyter/collaboration_sessions.json').
+# Useful for the same reasons as above, or to keep the launch directory free of generated state.
+jupyter lab --YDocExtension.session_store_path=/path/to/sessions.json
 ```
 
 There is an experimental feature that is currently only supported by the

--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -26,7 +26,8 @@ fine to just ignore it, including in your version control system (don't commit t
 you happen to delete it, there shouldn't be any serious consequence either.
 
 A second file, `collaboration_sessions.json`, is created inside a `.jupyter` directory under
-that same launch directory. It records recent collaboration session IDs so the backend can
+the server's root directory (`ServerApp.root_dir`, which defaults to the directory where
+JupyterLab was launched). It records recent collaboration session IDs so the backend can
 detect when a client is reconnecting after a server restart or version change, and prompt for
 a reload when the session can no longer be resumed safely. Like the YStore database, it is
 safe to ignore in version control and safe to delete (clients will simply be asked to reload

--- a/docs/source/configuration.md
+++ b/docs/source/configuration.md
@@ -55,12 +55,10 @@ jupyter lab --YDocExtension.document_cleanup_delay=100
 jupyter lab --YDocExtension.ystore_class=pycrdt.store.TempFileYStore
 
 # Relocate the YStore SQLite database (default: '.jupyter_ystore.db' in the launch directory).
-# Useful when the launch directory is read-only, under version control, or shared between users.
 jupyter lab --SQLiteYStore.db_path=/path/to/ystore.db
 
 # Relocate the collaboration session store
 # (default: '<server_root_dir>/.jupyter/collaboration_sessions.json').
-# Useful for the same reasons as above, or to keep the launch directory free of generated state.
 jupyter lab --YDocExtension.session_store_path=/path/to/sessions.json
 ```
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/app.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/app.py
@@ -12,7 +12,7 @@ from jupyter_ydoc import ydocs as YDOCS
 from jupyter_ydoc.ybasedoc import YBaseDoc
 from pycrdt import Doc
 from pycrdt.store import BaseYStore
-from traitlets import Bool, Float, Type
+from traitlets import Bool, Float, Type, Unicode
 
 from .handlers import (
     DocForkHandler,
@@ -93,6 +93,17 @@ class YDocExtension(ExtensionApp):
         model.""",
     )
 
+    session_store_path = Unicode(
+        None,
+        allow_none=True,
+        config=True,
+        help="""Path to the JSON file used to record collaboration session IDs for
+        reconnect compatibility checks. When unset, defaults to
+        ``<server_root_dir>/.jupyter/collaboration_sessions.json``. Set this to
+        relocate the file (for example into a per-user data directory) so the
+        server root stays free of generated state.""",
+    )
+
     _room_locks: dict[str, asyncio.Lock] = defaultdict(asyncio.Lock)
 
     def initialize(self):
@@ -108,6 +119,7 @@ class YDocExtension(ExtensionApp):
                 "collaborative_document_cleanup_delay": self.document_cleanup_delay,
                 "collaborative_document_save_delay": self.document_save_delay,
                 "collaborative_ystore_class": self.ystore_class,
+                "collaborative_session_store_path": self.session_store_path,
             }
         )
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/app.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/app.py
@@ -100,7 +100,7 @@ class YDocExtension(ExtensionApp):
         help="""Path to the JSON file used to record collaboration session IDs for
         reconnect compatibility checks. When unset, defaults to
         ``<server_root_dir>/.jupyter/collaboration_sessions.json``. Set this to
-        relocate the file (for example into a per-user data directory) so the
+        relocate the file (for example into a dedicated data directory) so the
         server root stays free of generated state.""",
     )
 

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/handlers.py
@@ -240,6 +240,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
             # Close the connection if the document session expired
             session_id = self.get_query_argument("sessionId", "")
             root_dir = self.settings.get("server_root_dir", os.getcwd())
+            session_store_path = self.settings.get("collaborative_session_store_path")
             document_version = getattr(self.room._document, "version", None)
 
             # Persist the current session so future reconnects can validate it
@@ -249,6 +250,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
                 YDOC_SERVER_VERSION,
                 self._session_file_lock,
                 document_version=document_version,
+                session_store_path=session_store_path,
             )
             if SERVER_SESSION != session_id:
                 cannot_reconnect, reason = check_session_compatibility(
@@ -256,6 +258,7 @@ class YDocWebSocketHandler(WebSocketHandler, JupyterHandler):
                     session_id,
                     YDOC_SERVER_VERSION,
                     current_document_version=document_version,
+                    session_store_path=session_store_path,
                 )
                 if cannot_reconnect:
                     # Must ask the user to reload

--- a/projects/jupyter-server-ydoc/jupyter_server_ydoc/utils.py
+++ b/projects/jupyter-server-ydoc/jupyter_server_ydoc/utils.py
@@ -87,8 +87,23 @@ def room_id_from_encoded_path(encoded_path: str) -> str:
     return encoded_path.split("/")[-1]
 
 
-def _get_jupyter_session_store(root_dir: str) -> Path:
-    """Return path to the session store file in .jupyter folder."""
+def _get_jupyter_session_store(root_dir: str, session_store_path: str | None = None) -> Path:
+    """Return path to the session store file.
+
+    If ``session_store_path`` is provided it is honored as-is (its parent
+    directory is created on demand). Otherwise the default location
+    ``<root_dir>/.jupyter/collaboration_sessions.json`` is used.
+    """
+    if session_store_path:
+        try:
+            target = Path(session_store_path).expanduser()
+            target.parent.mkdir(parents=True, exist_ok=True)
+            return target
+        except OSError:
+            # Configured path is unwritable — fall through to /dev/null so the
+            # server stays up; callers tolerate write failures already.
+            return Path(os.devnull)
+
     try:
         expanded = Path(root_dir).expanduser()
         resolved = expanded.resolve()
@@ -100,9 +115,9 @@ def _get_jupyter_session_store(root_dir: str) -> Path:
         return Path(os.devnull)
 
 
-def _load_previous_sessions(root_dir: str) -> dict:
+def _load_previous_sessions(root_dir: str, session_store_path: str | None = None) -> dict:
     """Load previous session records from .jupyter folder."""
-    store_path = _get_jupyter_session_store(root_dir)
+    store_path = _get_jupyter_session_store(root_dir, session_store_path)
     if store_path.exists():
         try:
             sessions = json.loads(store_path.read_text())
@@ -125,12 +140,13 @@ async def save_current_session(
     version: str,
     lock: asyncio.Lock,
     document_version: str | None = None,
+    session_store_path: str | None = None,
 ) -> None:
     """Persist the current session ID, server version, and optionally
-    document version to .jupyter folder."""
+    document version to the session store."""
     async with lock:
-        store_path = _get_jupyter_session_store(root_dir)
-        sessions = _load_previous_sessions(root_dir)
+        store_path = _get_jupyter_session_store(root_dir, session_store_path)
+        sessions = _load_previous_sessions(root_dir, session_store_path)
 
         sessions[session_id] = {
             "version": version,
@@ -154,6 +170,7 @@ def check_session_compatibility(
     client_session_id: str,
     current_version: str,
     current_document_version: str | None = None,
+    session_store_path: str | None = None,
 ) -> tuple[bool, str]:
     """
     Determine whether a client carrying an old session ID can reconnect or not.
@@ -164,7 +181,7 @@ def check_session_compatibility(
     if client_session_id == SERVER_SESSION:
         return False, ""
 
-    previous_sessions = _load_previous_sessions(root_dir)
+    previous_sessions = _load_previous_sessions(root_dir, session_store_path)
 
     # Session ID not in our records at all → unknown origin, reject
     if client_session_id not in previous_sessions:

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -2,9 +2,11 @@
 # Distributed under the terms of the Modified BSD License.
 
 import asyncio
+import json
 
 from jupyter_server_ydoc.utils import (
     YDOC_SERVER_VERSION,
+    _get_jupyter_session_store,
     check_session_compatibility,
     save_current_session,
 )
@@ -102,3 +104,62 @@ async def test_allows_reconnect_without_document_version_in_old_session(tmp_path
     )
     assert cannot_reconnect is False
     assert reason == ""
+
+
+def test_session_store_path_override_used_when_set(tmp_path):
+    """``session_store_path`` overrides the default ``.jupyter`` location."""
+    override = tmp_path / "elsewhere" / "sessions.json"
+    resolved = _get_jupyter_session_store(str(tmp_path), str(override))
+    # The override directory is created on demand and the file path is honored as-is.
+    assert resolved == override
+    assert override.parent.is_dir()
+    # The default location should not have been created.
+    assert not (tmp_path / ".jupyter").exists()
+
+
+async def test_session_store_path_override_persists_records(tmp_path):
+    """Saved sessions land under the override path and reconnects honor it."""
+    override = tmp_path / "elsewhere" / "sessions.json"
+    await save_current_session(
+        str(tmp_path),
+        "override-session",
+        YDOC_SERVER_VERSION,
+        asyncio.Lock(),
+        session_store_path=str(override),
+    )
+
+    assert override.exists()
+    payload = json.loads(override.read_text())
+    assert "override-session" in payload
+    # The default location must remain untouched.
+    assert not (tmp_path / ".jupyter" / "collaboration_sessions.json").exists()
+
+    cannot_reconnect, reason = check_session_compatibility(
+        str(tmp_path),
+        "override-session",
+        YDOC_SERVER_VERSION,
+        session_store_path=str(override),
+    )
+    assert cannot_reconnect is False
+    assert reason == ""
+
+
+async def test_session_store_path_override_isolated_from_default(tmp_path):
+    """Records saved with an override are invisible to the default lookup."""
+    override = tmp_path / "elsewhere" / "sessions.json"
+    await save_current_session(
+        str(tmp_path),
+        "override-session",
+        YDOC_SERVER_VERSION,
+        asyncio.Lock(),
+        session_store_path=str(override),
+    )
+
+    # Without the override, the default lookup should treat the session as unknown.
+    cannot_reconnect, reason = check_session_compatibility(
+        str(tmp_path),
+        "override-session",
+        YDOC_SERVER_VERSION,
+    )
+    assert cannot_reconnect is True
+    assert reason == "unknown_session"

--- a/tests/test_session_store.py
+++ b/tests/test_session_store.py
@@ -6,7 +6,6 @@ import json
 
 from jupyter_server_ydoc.utils import (
     YDOC_SERVER_VERSION,
-    _get_jupyter_session_store,
     check_session_compatibility,
     save_current_session,
 )
@@ -106,17 +105,6 @@ async def test_allows_reconnect_without_document_version_in_old_session(tmp_path
     assert reason == ""
 
 
-def test_session_store_path_override_used_when_set(tmp_path):
-    """``session_store_path`` overrides the default ``.jupyter`` location."""
-    override = tmp_path / "elsewhere" / "sessions.json"
-    resolved = _get_jupyter_session_store(str(tmp_path), str(override))
-    # The override directory is created on demand and the file path is honored as-is.
-    assert resolved == override
-    assert override.parent.is_dir()
-    # The default location should not have been created.
-    assert not (tmp_path / ".jupyter").exists()
-
-
 async def test_session_store_path_override_persists_records(tmp_path):
     """Saved sessions land under the override path and reconnects honor it."""
     override = tmp_path / "elsewhere" / "sessions.json"
@@ -131,8 +119,8 @@ async def test_session_store_path_override_persists_records(tmp_path):
     assert override.exists()
     payload = json.loads(override.read_text())
     assert "override-session" in payload
-    # The default location must remain untouched.
-    assert not (tmp_path / ".jupyter" / "collaboration_sessions.json").exists()
+    # The default ``.jupyter`` directory should never be created when an override is set.
+    assert not (tmp_path / ".jupyter").exists()
 
     cannot_reconnect, reason = check_session_compatibility(
         str(tmp_path),


### PR DESCRIPTION
Follow-up to https://github.com/jupyterlab/jupyter-collaboration/pull/548

This makes it possible to configure where the JSON file is saved with the following:

```bash
jupyter lab --YDocExtension.session_store_path=/path/to/sessions.json
```

To avoid leaving git repos in a dirty state:

<img width="856" height="178" alt="image" src="https://github.com/user-attachments/assets/e6c48bf2-527e-4aa6-bb35-2527548c44d6" />
