### PR TITLE
ci: drop the `|| <cmd> --lf` test retry

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -163,7 +163,7 @@ jobs:
 
       - name: Run the unit tests
         run: |
-          pytest -vv -W default || pytest -vv -W default --lf
+          pytest -vv -W default
 
   test_prereleases:
     name: Test Prereleases
@@ -188,7 +188,7 @@ jobs:
 
       - name: Run the tests
         run: |
-          pytest -vv -W default || pytest -vv --lf
+          pytest -vv -W default
 
   make_sdist:
     name: Make SDist


### PR DESCRIPTION
The `pytest ... || pytest ... --lf` pattern was meant to re-run only the failed tests once, to paper over flakes. It is unsound:

- If the first invocation dies before writing the `lastfailed` cache (crash, OOM, timeout, segfault, collection/import error, or a failure in the surrounding tooling rather than in the tests), there is no recorded failure to re-run. `--lf` then falls back to `--lfnf=all`-style behaviour or selects nothing, so the retry does not reproduce what failed and its exit status is unrelated to the original failure.
- Because the retry's status is what the step reports, a genuine failure of the first command is silently masked whenever the retry happens to succeed. This also swallows non-test failures such as `--cov-fail-under` thresholds.

Run the test command once and let its exit status stand.